### PR TITLE
Add `tick` to MultiProgress to complement `join`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,7 +187,9 @@ mod utils;
 
 pub use crate::format::{BinaryBytes, DecimalBytes, FormattedDuration, HumanBytes, HumanDuration};
 pub use crate::iter::{ProgressBarIter, ProgressIterator};
-pub use crate::progress::{MultiProgress, ProgressBar, ProgressBarWrap, ProgressDrawTarget};
+pub use crate::progress::{
+    MultiProgress, ProgressBar, ProgressBarWrap, ProgressDrawTarget, TickTimeLimit,
+};
 pub use crate::style::ProgressStyle;
 
 #[cfg(feature = "with_rayon")]


### PR DESCRIPTION
* Changed `joining` field of `MultiProgress` from `AtomicBool` to `Mutex`.
  Because the internal `join_impl` can now be called multiple times
  I figured it's better to use a Mutex as it automatically unlocks
  preventing panics "bricking" the progress bar.
* Because MultiProgress can contain multiple child progress bars I feel
  like the meaning of a single tick isn't really clear. Just a single
  state update (`self.rx.recv()`) seems too small. Because of that I
  allow the user to configure how long do they want a tick to last
  adding greater flexibility.
* Made `is_done` public to let the user know whether they still need
  to invoke `tick`

Fixes #33, seems like fixes #125