### PR TITLE
[RFC] Threaded draw

### DIFF
--- a/examples/multi-synced.rs
+++ b/examples/multi-synced.rs
@@ -1,0 +1,27 @@
+// From https://github.com/mitsuhiko/indicatif/pull/166
+
+use std::thread;
+use std::time::Duration;
+
+use indicatif::{MultiProgress, ProgressBar};
+
+fn main() {
+    let mpb = MultiProgress::new();
+    let pb1 = mpb.add(ProgressBar::new(30));
+    let pb2 = mpb.add(ProgressBar::new(30));
+
+    let _ = thread::spawn(move || {
+        for _ in 0..30 {
+            pb1.inc(1);
+            thread::sleep(Duration::from_millis(1000));
+        }
+    });
+    let _ = thread::spawn(move || {
+        for _ in 0..30 {
+            pb2.inc(1);
+            thread::sleep(Duration::from_millis(1000));
+        }
+    });
+
+    mpb.join().unwrap();
+}

--- a/examples/single-synced.rs
+++ b/examples/single-synced.rs
@@ -1,0 +1,16 @@
+use std::thread;
+use std::time::Duration;
+
+use indicatif::ProgressBar;
+
+fn main() {
+    let p = ProgressBar::new_spinner();
+    for _ in 0..10 {
+        p.set_message("doing fast work (you should rarely see this)");
+        // Any sleep shorter than the default redraw interval (15 Hz) should have the same effect,
+        // as should not sleeping at all.
+        thread::sleep(Duration::from_millis(5));
+        p.set_message("doing slow work");
+        thread::sleep(Duration::from_secs(1));
+    }
+}


### PR DESCRIPTION
This PR could be merged by itself, but it makes more sense when combined with #231, which removes batching from MultiProgress.

The new code is slower for code that updates very frequently, because the channel send is not cheap enough. I'm working on some optimizations of format_state to balance that out.

I'm not sure how much the change in behavior for code that does not finish its progress bars affects real code.