### PR TITLE
Enable `ansi-parsing` feature for `console`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["screenshots/*"]
 regex = { version = "1.3.1", default-features = false, features = ["std"] }
 lazy_static = "1.0"
 number_prefix = "0.4"
-console = { version = "0.15.0", default-features = false }
+console = { version = "0.15.0", default-features = false, features = ["ansi-parsing"] }
 unicode-segmentation = { version = "1.6.0", optional = true }
 unicode-width = { version = "0.1.7", optional = true }
 rayon = { version = "1.0", optional = true }


### PR DESCRIPTION
Fixes #300.

As it turns out, `console`'s `strip_ansi_codes` function is a no-op unless the `ansi-parsing` feature is enabled (https://docs.rs/console/0.15.0/src/console/utils.rs.html#10-16).