### PR TITLE
Remove the extra space, and make the wide element fill the whole term…

### DIFF
--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -396,9 +396,6 @@ impl ProgressDrawState {
             } else {
                 // Don't append a '\n' if this is the last line
                 term.write_str(line)?;
-                // Also append a ' ' to keep the original chars count
-                // This is important if the line was meant to fill the entire width
-                term.write_str(" ")?;
             }
         }
         Ok(())

--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -396,6 +396,10 @@ impl ProgressDrawState {
             } else {
                 // Don't append a '\n' if this is the last line
                 term.write_str(line)?;
+                // Keep the cursor on the right terminal side
+                // So that next user writes/prints will happen on the next line
+                let line_width = console::measure_text_width(line);
+                term.move_cursor_right(usize::from(term.size().1) - line_width)?;
             }
         }
         Ok(())

--- a/src/style.rs
+++ b/src/style.rs
@@ -391,6 +391,7 @@ impl<'a> WideElement<'a> {
         buf: &mut String,
     ) -> String {
         let left = state.width().saturating_sub(measure_text_width(&cur));
+        let left = left + 1; // Add 1 to cover the whole terminal width
         match self {
             Self::Bar { alt_style } => cur.replace(
                 "\x00",


### PR DESCRIPTION
…inal width

fix https://github.com/console-rs/indicatif/issues/348
fix https://github.com/console-rs/indicatif/issues/342 again

Recap of the situation:
- https://github.com/console-rs/indicatif/pull/338 removed the extra line that indicatif always adds
- But now issue like  #342 happens
- Initially I thought just adding an extra space is a good idea to fill the width
- But that looks weird, so the new solution is to increase the wide elements size to fill the terminal width

If no wide elements is used, any printing after will happen on the same line as the progress bar, this might be not what users expects but I think its a desirable change, and reverting to the old behavior is a simple as adding println!() after the progress bar