### PR TITLE
MultiProgress: add println and suspend implementation

### DIFF
--- a/examples/multi.rs
+++ b/examples/multi.rs
@@ -20,15 +20,20 @@ fn main() {
     let pb3 = m.insert_after(&pb2, ProgressBar::new(1024));
     pb3.set_style(sty);
 
+    m.println("starting!").unwrap();
+
+    let m_clone = m.clone();
     let h1 = thread::spawn(move || {
         for i in 0..128 {
             pb.set_message(format!("item #{}", i + 1));
             pb.inc(1);
             thread::sleep(Duration::from_millis(15));
         }
+        m_clone.println("pb1 is done!").unwrap();
         pb.finish_with_message("done");
     });
 
+    let m_clone = m.clone();
     let h2 = thread::spawn(move || {
         for _ in 0..3 {
             pb2.set_position(0);
@@ -38,15 +43,18 @@ fn main() {
                 thread::sleep(Duration::from_millis(8));
             }
         }
+        m_clone.println("pb2 is done!").unwrap();
         pb2.finish_with_message("done");
     });
 
+    let m_clone = m.clone();
     let _ = thread::spawn(move || {
         for i in 0..1024 {
             pb3.set_message(format!("item #{}", i + 1));
             pb3.inc(1);
             thread::sleep(Duration::from_millis(2));
         }
+        m_clone.println("pb3 is done!").unwrap();
         pb3.finish_with_message("done");
     });
 

--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -256,7 +256,7 @@ impl<'a> Drawable<'a> {
                 force_draw,
                 now,
                 ..
-            } => state.draw(force_draw, now),
+            } => state.draw(force_draw, None, now),
             Drawable::TermLike {
                 term_like,
                 last_line_count,

--- a/src/in_memory.rs
+++ b/src/in_memory.rs
@@ -54,31 +54,47 @@ impl TermLike for InMemoryTerm {
     }
 
     fn move_cursor_up(&self, n: usize) -> std::io::Result<()> {
-        self.state
-            .lock()
-            .unwrap()
-            .write_str(&*format!("\x1b[{}A", n))
+        match n {
+            0 => Ok(()),
+            _ => self
+                .state
+                .lock()
+                .unwrap()
+                .write_str(&*format!("\x1b[{}A", n)),
+        }
     }
 
     fn move_cursor_down(&self, n: usize) -> std::io::Result<()> {
-        self.state
-            .lock()
-            .unwrap()
-            .write_str(&*format!("\x1b[{}B", n))
+        match n {
+            0 => Ok(()),
+            _ => self
+                .state
+                .lock()
+                .unwrap()
+                .write_str(&*format!("\x1b[{}B", n)),
+        }
     }
 
     fn move_cursor_right(&self, n: usize) -> std::io::Result<()> {
-        self.state
-            .lock()
-            .unwrap()
-            .write_str(&*format!("\x1b[{}C", n))
+        match n {
+            0 => Ok(()),
+            _ => self
+                .state
+                .lock()
+                .unwrap()
+                .write_str(&*format!("\x1b[{}C", n)),
+        }
     }
 
     fn move_cursor_left(&self, n: usize) -> std::io::Result<()> {
-        self.state
-            .lock()
-            .unwrap()
-            .write_str(&*format!("\x1b[{}D", n))
+        match n {
+            0 => Ok(()),
+            _ => self
+                .state
+                .lock()
+                .unwrap()
+                .write_str(&*format!("\x1b[{}D", n)),
+        }
     }
 
     fn write_line(&self, s: &str) -> std::io::Result<()> {
@@ -210,5 +226,28 @@ mod test {
         in_mem.write_line("LINE FOUR").unwrap();
 
         assert_eq!(in_mem.contents(), "LINE ONE\nLINE TWO\n\nLINE FOUR");
+    }
+
+    #[test]
+    fn cursor_zero_movement() {
+        let in_mem = InMemoryTerm::new(10, 80);
+        in_mem.write_line("LINE ONE").unwrap();
+        assert_eq!(cursor_pos(&in_mem), (1, 0));
+
+        // Check that moving zero rows/cols does not actually move cursor
+        in_mem.move_cursor_up(0).unwrap();
+        assert_eq!(cursor_pos(&in_mem), (1, 0));
+
+        in_mem.move_cursor_down(0).unwrap();
+        assert_eq!(cursor_pos(&in_mem), (1, 0));
+
+        in_mem.move_cursor_right(1).unwrap();
+        assert_eq!(cursor_pos(&in_mem), (1, 1));
+
+        in_mem.move_cursor_left(0).unwrap();
+        assert_eq!(cursor_pos(&in_mem), (1, 1));
+
+        in_mem.move_cursor_right(0).unwrap();
+        assert_eq!(cursor_pos(&in_mem), (1, 1));
     }
 }

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -299,8 +299,9 @@ impl MultiState {
             }
         }
 
-        assert!(
-            self.len() == self.ordering.len(),
+        assert_eq!(
+            self.len(),
+            self.ordering.len(),
             "Draw state is inconsistent"
         );
 
@@ -323,8 +324,9 @@ impl MultiState {
         self.free_set.push(idx);
         self.ordering.retain(|&x| x != idx);
 
-        assert!(
-            self.len() == self.ordering.len(),
+        assert_eq!(
+            self.len(),
+            self.ordering.len(),
             "Draw state is inconsistent"
         );
     }

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -6,7 +6,7 @@ use crate::draw_target::{DrawState, DrawStateWrapper, ProgressDrawTarget};
 use crate::progress_bar::ProgressBar;
 
 /// Manages multiple progress bars from different threads
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MultiProgress {
     pub(crate) state: Arc<RwLock<MultiState>>,
 }

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -1,6 +1,8 @@
 #![cfg(feature = "in_memory")]
 
-use indicatif::{InMemoryTerm, MultiProgress, ProgressBar, ProgressDrawTarget, ProgressFinish};
+use indicatif::{
+    InMemoryTerm, MultiProgress, ProgressBar, ProgressDrawTarget, ProgressFinish, TermLike,
+};
 
 #[test]
 fn basic_progress_bar() {
@@ -74,5 +76,144 @@ fn multi_progress() {
     assert_eq!(
         in_mem.contents(),
         r#"██████████████████████████████████████████████████████████████████████████ 10/10"#
+    );
+}
+
+#[test]
+fn multi_progress_println() {
+    let in_mem = InMemoryTerm::new(10, 80);
+    let mp =
+        MultiProgress::with_draw_target(ProgressDrawTarget::term_like(Box::new(in_mem.clone())));
+
+    let pb1 = mp.add(ProgressBar::new(10));
+    let pb2 = mp.add(ProgressBar::new(5));
+    let pb3 = mp.add(ProgressBar::new(100));
+
+    assert_eq!(in_mem.contents(), "");
+
+    pb1.inc(2);
+    mp.println("message printed :)").unwrap();
+
+    assert_eq!(
+        in_mem.contents(),
+        r#"
+message printed :)
+███████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 2/10
+            "#
+        .trim()
+    );
+
+    mp.println("another great message!").unwrap();
+    assert_eq!(
+        in_mem.contents(),
+        r#"
+message printed :)
+another great message!
+███████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 2/10
+            "#
+        .trim()
+    );
+
+    pb2.inc(1);
+    pb3.tick();
+    mp.println("one last message").unwrap();
+
+    assert_eq!(
+        in_mem.contents(),
+        r#"
+message printed :)
+another great message!
+one last message
+███████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 2/10
+███████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 1/5
+░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 0/100
+        "#
+        .trim()
+    );
+
+    drop(pb1);
+    drop(pb2);
+    drop(pb3);
+
+    assert_eq!(
+        in_mem.contents(),
+        r#"
+message printed :)
+another great message!
+one last message"#
+            .trim()
+    );
+}
+
+#[test]
+fn multi_progress_suspend() {
+    let in_mem = InMemoryTerm::new(10, 80);
+    let mp =
+        MultiProgress::with_draw_target(ProgressDrawTarget::term_like(Box::new(in_mem.clone())));
+
+    let pb1 = mp.add(ProgressBar::new(10));
+    let pb2 = mp.add(ProgressBar::new(10));
+
+    assert_eq!(in_mem.contents(), "");
+
+    pb1.inc(2);
+    mp.println("message printed :)").unwrap();
+
+    assert_eq!(
+        in_mem.contents(),
+        r#"
+message printed :)
+███████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 2/10
+            "#
+        .trim()
+    );
+
+    mp.suspend(|| {
+        in_mem.write_line("This is write_line output!").unwrap();
+        in_mem.write_line("And so is this").unwrap();
+        in_mem.move_cursor_down(1).unwrap();
+    });
+
+    assert_eq!(
+        in_mem.contents(),
+        r#"
+message printed :)
+This is write_line output!
+And so is this
+
+███████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 2/10
+            "#
+        .trim()
+    );
+
+    pb2.inc(1);
+    mp.println("Another line printed").unwrap();
+
+    assert_eq!(
+        in_mem.contents(),
+        r#"
+message printed :)
+This is write_line output!
+And so is this
+
+Another line printed
+███████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 2/10
+███████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 1/10
+            "#
+        .trim()
+    );
+
+    drop(pb1);
+    drop(pb2);
+
+    assert_eq!(
+        in_mem.contents(),
+        r#"
+message printed :)
+This is write_line output!
+And so is this
+
+Another line printed"#
+            .trim()
     );
 }


### PR DESCRIPTION
Work-in-progress pull request for implementing println. This does not currently work as nothing is printed for some reason. I have reason to believe it is due to an interaction with e46ca83e, since if you change the line below to `m.println("Starting...\n\n")` it works.