### PR TITLE
introduce TermLike trait; add InMemoryTerm 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,11 +11,25 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         rust: [stable, beta, 1.51]
+        features: [--all-features, ""]
+        include:
+          - rust: 1.51
+            os: ubuntu-latest
+            features: --features improved_unicode
+          - rust: 1.51
+            os: macos-latest
+            features: --features improved_unicode
+          - rust: 1.51
+            os: windows-latest
+            features: --features improved_unicode
         exclude:
           - os: macos-latest
             rust: beta
           - os: windows-latest
             rust: beta
+          # Can't use vt100 with 1.51 since it is 2021.1 edition
+          - rust: 1.51
+            features: --all-features
 
     runs-on: ${{ matrix.os }}
 
@@ -37,7 +51,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --all-features
+          args: --workspace ${{ matrix.features }}
 
   lint:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ rayon = { version = "1.1", optional = true }
 tokio = { version = "1", optional = true, features = ["fs", "io-util"] }
 unicode-segmentation = { version = "1", optional = true }
 unicode-width = { version = "0.1", optional = true }
+vt100 = { version = "0.15.1", optional = true }
 
 [dev-dependencies]
 once_cell = "1"
@@ -28,6 +29,7 @@ tokio = { version = "1", features = ["time", "rt"] }
 [features]
 default = ["unicode-width", "console/unicode-width"]
 improved_unicode = ["unicode-segmentation", "unicode-width", "console/unicode-width"]
+in_memory = ["vt100"]
 
 # Legacy alias for `rayon`
 with_rayon = ["rayon"]

--- a/src/in_memory.rs
+++ b/src/in_memory.rs
@@ -1,0 +1,216 @@
+use std::fmt::{Debug, Formatter};
+use std::io::Write;
+use std::sync::{Arc, Mutex};
+
+use vt100::Parser;
+
+use crate::TermLike;
+
+/// A thin wrapper around [`vt100::Parser`].
+///
+/// This is just an [`Arc`] around its internal state, so it can be freely cloned.
+#[derive(Debug, Clone)]
+pub struct InMemoryTerm {
+    state: Arc<Mutex<InMemoryTermState>>,
+}
+
+impl InMemoryTerm {
+    pub fn new(rows: u16, cols: u16) -> InMemoryTerm {
+        assert!(rows > 0, "rows must be > 0");
+        assert!(cols > 0, "cols must be > 0");
+        InMemoryTerm {
+            state: Arc::new(Mutex::new(InMemoryTermState::new(rows, cols))),
+        }
+    }
+
+    pub fn contents(&self) -> String {
+        let state = self.state.lock().unwrap();
+
+        // For some reason, the `Screen::contents` method doesn't include newlines in what it
+        // returns, making it useless for our purposes. So we need to manually reconstruct the
+        // contents by iterating over the rows in the terminal buffer.
+        let mut rows = state
+            .parser
+            .screen()
+            .rows(0, state.width)
+            .collect::<Vec<_>>();
+
+        // Reverse the rows and trim empty lines from the end
+        rows = rows
+            .into_iter()
+            .rev()
+            .skip_while(|line| line.is_empty())
+            .collect();
+
+        // Un-reverse the rows and join them up with newlines
+        rows.reverse();
+        rows.join("\n")
+    }
+}
+
+impl TermLike for InMemoryTerm {
+    fn width(&self) -> usize {
+        self.state.lock().unwrap().width as usize
+    }
+
+    fn move_cursor_up(&self, n: usize) -> std::io::Result<()> {
+        self.state
+            .lock()
+            .unwrap()
+            .write_str(&*format!("\x1b[{}A", n))
+    }
+
+    fn move_cursor_down(&self, n: usize) -> std::io::Result<()> {
+        self.state
+            .lock()
+            .unwrap()
+            .write_str(&*format!("\x1b[{}B", n))
+    }
+
+    fn move_cursor_right(&self, n: usize) -> std::io::Result<()> {
+        self.state
+            .lock()
+            .unwrap()
+            .write_str(&*format!("\x1b[{}C", n))
+    }
+
+    fn move_cursor_left(&self, n: usize) -> std::io::Result<()> {
+        self.state
+            .lock()
+            .unwrap()
+            .write_str(&*format!("\x1b[{}D", n))
+    }
+
+    fn write_line(&self, s: &str) -> std::io::Result<()> {
+        let mut state = self.state.lock().unwrap();
+        state.write_str(s)?;
+        if (s.len() < state.width as usize) && !s.ends_with('\n') {
+            state.write_str("\n")
+        } else {
+            Ok(())
+        }
+    }
+
+    fn write_str(&self, s: &str) -> std::io::Result<()> {
+        self.state.lock().unwrap().write_str(s)
+    }
+
+    fn clear_line(&self) -> std::io::Result<()> {
+        self.state.lock().unwrap().write_str("\r\x1b[2K")
+    }
+
+    fn flush(&self) -> std::io::Result<()> {
+        self.state.lock().unwrap().parser.flush()
+    }
+}
+
+struct InMemoryTermState {
+    width: u16,
+    parser: vt100::Parser,
+}
+
+impl InMemoryTermState {
+    pub(crate) fn new(rows: u16, cols: u16) -> InMemoryTermState {
+        InMemoryTermState {
+            width: cols,
+            parser: Parser::new(rows, cols, 0),
+        }
+    }
+
+    pub(crate) fn write_str(&mut self, s: &str) -> std::io::Result<()> {
+        self.parser.write_all(s.as_bytes())
+    }
+}
+
+impl Debug for InMemoryTermState {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InMemoryTermState").finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressFinish, ProgressStyle};
+
+    #[test]
+    fn basic_progress_bar() {
+        let in_mem = InMemoryTerm::new(10, 80);
+        let pb = ProgressBar::with_draw_target(
+            10,
+            ProgressDrawTarget::term_like(Box::new(in_mem.clone())),
+        );
+
+        assert_eq!(in_mem.contents(), String::new());
+
+        pb.tick();
+        assert_eq!(
+            in_mem.contents(),
+            "░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 0/10"
+        );
+
+        pb.inc(1);
+        assert_eq!(
+            in_mem.contents(),
+            "███████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 1/10"
+        );
+
+        pb.finish();
+        assert_eq!(
+            in_mem.contents(),
+            "██████████████████████████████████████████████████████████████████████████ 10/10"
+        );
+    }
+
+    #[test]
+    fn multi_progress() {
+        let in_mem = InMemoryTerm::new(10, 80);
+        let mp = MultiProgress::with_draw_target(ProgressDrawTarget::term_like(Box::new(
+            in_mem.clone(),
+        )));
+
+        let pb1 = mp.add(
+            ProgressBar::new(10)
+                .with_style(ProgressStyle::default_bar().on_finish(ProgressFinish::AndLeave)),
+        );
+        let pb2 = mp.add(ProgressBar::new(5));
+        let pb3 = mp.add(ProgressBar::new(100));
+
+        assert_eq!(in_mem.contents(), String::new());
+
+        pb1.tick();
+        assert_eq!(
+            in_mem.contents(),
+            r#"░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 0/10"#
+        );
+
+        pb2.tick();
+
+        assert_eq!(
+            in_mem.contents(),
+            r#"
+░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 0/10
+░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 0/5"#
+                .trim_start()
+        );
+
+        pb3.tick();
+        assert_eq!(
+            in_mem.contents(),
+            r#"
+░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 0/10
+░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 0/5
+░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 0/100"#
+                .trim_start()
+        );
+
+        drop(pb1);
+        drop(pb2);
+        drop(pb3);
+
+        assert_eq!(
+            in_mem.contents(),
+            r#"██████████████████████████████████████████████████████████████████████████ 10/10"#
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,6 +216,8 @@
 
 mod draw_target;
 mod format;
+#[cfg(feature = "in_memory")]
+mod in_memory;
 mod iter;
 mod multi;
 mod progress_bar;
@@ -229,6 +231,8 @@ pub use crate::draw_target::ProgressDrawTarget;
 pub use crate::format::{
     BinaryBytes, DecimalBytes, FormattedDuration, HumanBytes, HumanCount, HumanDuration,
 };
+#[cfg(feature = "in_memory")]
+pub use crate::in_memory::InMemoryTerm;
 pub use crate::iter::{ProgressBarIter, ProgressIterator};
 pub use crate::multi::{MultiProgress, MultiProgressAlignment};
 pub use crate::progress_bar::{ProgressBar, WeakProgressBar};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,6 +223,7 @@ mod progress_bar;
 mod rayon;
 mod state;
 mod style;
+mod term_like;
 
 pub use crate::draw_target::ProgressDrawTarget;
 pub use crate::format::{
@@ -232,6 +233,7 @@ pub use crate::iter::{ProgressBarIter, ProgressIterator};
 pub use crate::multi::{MultiProgress, MultiProgressAlignment};
 pub use crate::progress_bar::{ProgressBar, WeakProgressBar};
 pub use crate::style::{ProgressFinish, ProgressStyle};
+pub use crate::term_like::TermLike;
 
 #[cfg(feature = "rayon")]
 pub use crate::rayon::ParallelProgressIterator;

--- a/src/term_like.rs
+++ b/src/term_like.rs
@@ -1,0 +1,69 @@
+use console::Term;
+use std::fmt::Debug;
+use std::io;
+
+/// A trait for minimal terminal-like behavior.
+///
+/// Anything that implements this trait can be used a draw target via [`ProgressDrawTarget::term_like`].
+///
+/// See [`InMemoryTerm`] as an example.
+pub trait TermLike: Debug + Send + Sync {
+    /// Return the terminal width
+    fn width(&self) -> usize;
+
+    /// Move the cursor up by `n` lines
+    fn move_cursor_up(&self, n: usize) -> io::Result<()>;
+    /// Move the cursor down by `n` lines
+    fn move_cursor_down(&self, n: usize) -> io::Result<()>;
+    /// Move the cursor right by `n` lines
+    fn move_cursor_right(&self, n: usize) -> io::Result<()>;
+    /// Move the cursor left by `n` lines
+    fn move_cursor_left(&self, n: usize) -> io::Result<()>;
+
+    /// Write a string and add a newline.
+    fn write_line(&self, s: &str) -> io::Result<()>;
+    /// Write a string
+    fn write_str(&self, s: &str) -> io::Result<()>;
+    /// Clear the current line and reset the cursor to beginning of the line
+    fn clear_line(&self) -> io::Result<()>;
+
+    fn flush(&self) -> io::Result<()>;
+}
+
+impl TermLike for Term {
+    fn width(&self) -> usize {
+        self.size().1 as usize
+    }
+
+    fn move_cursor_up(&self, n: usize) -> io::Result<()> {
+        self.move_cursor_up(n)
+    }
+
+    fn move_cursor_down(&self, n: usize) -> io::Result<()> {
+        self.move_cursor_down(n)
+    }
+
+    fn move_cursor_right(&self, n: usize) -> io::Result<()> {
+        self.move_cursor_right(n)
+    }
+
+    fn move_cursor_left(&self, n: usize) -> io::Result<()> {
+        self.move_cursor_left(n)
+    }
+
+    fn write_line(&self, s: &str) -> io::Result<()> {
+        self.write_line(s)
+    }
+
+    fn write_str(&self, s: &str) -> io::Result<()> {
+        self.write_str(s)
+    }
+
+    fn clear_line(&self) -> io::Result<()> {
+        self.clear_line()
+    }
+
+    fn flush(&self) -> io::Result<()> {
+        self.flush()
+    }
+}


### PR DESCRIPTION
These changes make it possible to write tests that compare the visual output of progress bars to expected output.

The `TermLike` trait provides a common abstraction over the `console::Term` type and the new `InMemoryTerm`. The trait is made public so that users can develop their own custom draw targets, should the need arise.

`InMemoryTerm` is basically just a vector of lines, with a cursor that tracks the current line. 

Still to-do:
- [x] Document `TermLike` trait
- [x] De-duplicate code in `InMemoryTerm::write_line` and `InMemoryTerm::write_str`
- [x] Add a method to `InMemoryTerm` to expose the buffer contents 
- [x] Add a method to `InMemoryTerm` to reconstitute buffer contents as `String` (will replace the `buf_contents` method in `test` module)
