### PR TITLE
Actually keep the cursor on the right terminal side

### DIFF
--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -399,7 +399,7 @@ impl ProgressDrawState {
                 // Keep the cursor on the right terminal side
                 // So that next user writes/prints will happen on the next line
                 let line_width = console::measure_text_width(line);
-                term.move_cursor_right(usize::from(term.size().1) - line_width)?;
+                term.write_str(&" ".repeat(usize::from(term.size().1) - line_width))?;
             }
         }
         Ok(())


### PR DESCRIPTION
Test case:
```rust
use indicatif::{ProgressBar, ProgressStyle};

fn main() {
    let pb = ProgressBar::new(500).with_style(ProgressStyle::default_bar().template("hello {bar}"));
    for _ in 0..1024 {
        pb.inc(1);
    }
    pb.finish_with_message("done");
    println!("Something");
}
```

https://github.com/console-rs/indicatif/pull/350/commits/1b13d6f695e8f8954d2c5203a24cb9854f4f896a didn't actually work as you can see with the test case, apparently moving the cursor to the right will never reach the last column, writing spaces instead actually works 