### PR TITLE
Fix wide element styling to work with 'improved_unicode' feature as well

### DIFF
--- a/src/style.rs
+++ b/src/style.rs
@@ -390,8 +390,9 @@ impl<'a> WideElement<'a> {
         state: &ProgressState,
         buf: &mut String,
     ) -> String {
-        let left = state.width().saturating_sub(measure_text_width(&cur));
-        let left = left + 1; // Add 1 to cover the whole terminal width
+        let left = state
+            .width()
+            .saturating_sub(measure_text_width(&*cur.replace("\x00", "")));
         match self {
             Self::Bar { alt_style } => cur.replace(
                 "\x00",


### PR DESCRIPTION
From style.rs, line 385:

```
impl<'a> WideElement<'a> {
    fn expand(
        self,
        cur: String,
        style: &ProgressStyle,
        state: &ProgressState,
        buf: &mut String,
    ) -> String {
        let left = state.width().saturating_sub(measure_text_width(&cur));
        let left = left + 1; // Add 1 to cover the whole terminal width
```

When the `improved_unicode` feature is off, `measure_text_width` just counts characters. Consider the case of rendering the default progress bar style. `cur` will be something like `\x00 0/10`. In this case `measure_text_width` returns the width as 6 since it is counting the null byte. This bug is what led to the addition of line 394 to offset it (in #350):

    let left = left + 1; // Add 1 to cover the whole terminal width

When `improved_unicode` is on, `measure_text_width` correctly returns 5 because it ignores the control character. However, the aforementioned line adds a 1 which causes the progress bar to spill a character onto the next line of the terminal.

To reproduce, simply run `cargo test --features=improved_unicode` on current main branch. You will get several test failures caused by `'attempt to subtract with overflow', src/draw_target.rs:402:44`

None of the automated tests caught this because they run in an environment without a tty, so indicatif considers the bars "hidden" and thus nothing is rendered. I spotted this as part of developing the in-memory terminal (#354).