### PR TITLE
Draw progress bars into draw states

### DIFF
--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -464,7 +464,16 @@ impl ProgressDrawState {
         if !self.lines.is_empty() && self.move_cursor {
             term.move_cursor_up(*last_line_count)?;
         } else {
-            clear_last_lines(term, *last_line_count)?;
+            // Fork of console::clear_last_lines that assumes that the last line doesn't contain a '\n'
+            let n = *last_line_count;
+            term.move_cursor_up(n.saturating_sub(1))?;
+            for i in 0..n {
+                term.clear_line()?;
+                if i + 1 != n {
+                    term.move_cursor_down(1)?;
+                }
+            }
+            term.move_cursor_up(n.saturating_sub(1))?;
         }
 
         let shift = match self.alignment {
@@ -532,17 +541,4 @@ impl Default for MultiProgressAlignment {
     fn default() -> Self {
         Self::Top
     }
-}
-
-/// Fork of console::clear_last_lines that assumes that the last line doesn't contain a '\n'
-fn clear_last_lines(term: &Term, n: usize) -> io::Result<()> {
-    term.move_cursor_up(n.saturating_sub(1))?;
-    for i in 0..n {
-        term.clear_line()?;
-        if i + 1 != n {
-            term.move_cursor_down(1)?;
-        }
-    }
-    term.move_cursor_up(n.saturating_sub(1))?;
-    Ok(())
 }

--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -402,7 +402,7 @@ impl MultiProgressState {
 }
 
 #[derive(Debug)]
-pub(crate) struct LeakyBucket {
+struct LeakyBucket {
     leak_rate: f64,
     last_update: Instant,
     bucket: f64,

--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -231,6 +231,17 @@ pub(crate) struct MultiProgressState {
 }
 
 impl MultiProgressState {
+    pub(crate) fn new(draw_target: ProgressDrawTarget) -> Self {
+        Self {
+            draw_states: vec![],
+            free_set: vec![],
+            ordering: vec![],
+            draw_target,
+            move_cursor: false,
+            alignment: Default::default(),
+        }
+    }
+
     fn width(&self) -> usize {
         self.draw_target.width()
     }

--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -249,20 +249,15 @@ impl MultiProgressState {
         self.draw_target.width()
     }
 
-    pub(crate) fn draw(&mut self, idx: usize, draw_state: ProgressDrawState) -> io::Result<()> {
+    pub(crate) fn draw(&mut self, idx: usize, mut draw_state: ProgressDrawState) -> io::Result<()> {
         let force_draw = draw_state.force_draw;
 
         // Split orphan lines out of the draw state, if any
-        let lines = if draw_state.orphan_lines > 0 {
-            let split = draw_state.lines.split_at(draw_state.orphan_lines);
-            self.orphan_lines.extend_from_slice(split.0);
-            split.1.to_vec()
-        } else {
-            draw_state.lines
-        };
+        self.orphan_lines
+            .extend(draw_state.lines.drain(..draw_state.orphan_lines));
 
         let draw_state = ProgressDrawState {
-            lines,
+            lines: draw_state.lines,
             orphan_lines: 0,
             ..draw_state
         };

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -264,9 +264,9 @@ impl ProgressBar {
             .extend(msg.as_ref().lines().map(Into::into));
         draw_state.orphan_lines = draw_state.lines.len();
         if draw_lines {
-            draw_state
-                .lines
-                .extend(state.style.format_state(state, width));
+            state
+                .style
+                .format_state(state, &mut draw_state.lines, width);
         }
 
         drop(draw_state);

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -245,7 +245,7 @@ impl ProgressBar {
         let mut lines: Vec<String> = msg.as_ref().lines().map(Into::into).collect();
         let orphan_lines = lines.len();
         if state.should_render() && !state.draw_target.is_hidden() {
-            lines.extend(state.style.format_state(&*state));
+            lines.extend(state.style.format_state(&*state, state.draw_target.width()));
         }
 
         let draw_state = ProgressDrawState {

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -598,14 +598,7 @@ impl MultiProgress {
     /// Creates a new multi progress object with the given draw target.
     pub fn with_draw_target(draw_target: ProgressDrawTarget) -> MultiProgress {
         MultiProgress {
-            state: Arc::new(RwLock::new(MultiProgressState {
-                draw_states: Vec::new(),
-                free_set: Vec::new(),
-                ordering: vec![],
-                draw_target,
-                move_cursor: false,
-                alignment: Default::default(),
-            })),
+            state: Arc::new(RwLock::new(MultiProgressState::new(draw_target))),
         }
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -88,11 +88,6 @@ impl ProgressState {
         &self.prefix
     }
 
-    /// The entire draw width
-    pub fn width(&self) -> usize {
-        self.draw_target.width()
-    }
-
     /// The expected ETA
     pub fn eta(&self) -> Duration {
         if self.len == !0 || self.is_finished() {
@@ -235,7 +230,7 @@ impl ProgressState {
         }
 
         let lines = match self.should_render() {
-            true => self.style.format_state(self),
+            true => self.style.format_state(self, self.draw_target.width()),
             false => Vec::new(),
         };
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -120,10 +120,11 @@ impl BarState {
         // finished progress bar, so it's kept as to not cause compatibility issues in weird cases.
         draw_state.force_draw = force_draw || self.state.is_finished();
 
-        draw_state.lines = match self.state.should_render() {
-            true => self.state.style.format_state(&self.state, width),
-            false => Vec::new(),
-        };
+        if self.state.should_render() {
+            self.state
+                .style
+                .format_state(&self.state, &mut draw_state.lines, width);
+        }
 
         drop(draw_state);
         drawable.draw()

--- a/src/style.rs
+++ b/src/style.rs
@@ -718,7 +718,7 @@ mod tests {
         style.format_map.0.insert("bar", |_| "BAR".into());
         let draw_target = ProgressDrawTarget::stdout();
         let width = draw_target.width();
-        let state = ProgressState::new(10, draw_target);
+        let state = ProgressState::new(10);
 
         style.template = Template::from_str("{{ {foo} {bar} }}");
         let rv = style.format_state(&state, width);
@@ -737,7 +737,7 @@ mod tests {
         style.format_map.0.insert("foo", |_| "XXX".into());
         let draw_target = ProgressDrawTarget::stdout();
         let width = draw_target.width();
-        let state = ProgressState::new(10, draw_target);
+        let state = ProgressState::new(10);
 
         style.template = Template::from_str("{foo:5}");
         let rv = style.format_state(&state, width);


### PR DESCRIPTION
This clarifies the internal structure and avoids reallocating some buffers.