### PR TITLE
Fix panic when calculating padding spaces

### DIFF
--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -454,7 +454,7 @@ impl ProgressDrawState {
                 // Keep the cursor on the right terminal side
                 // So that next user writes/prints will happen on the next line
                 let line_width = console::measure_text_width(line);
-                term.write_str(&" ".repeat(term.width() - line_width))?;
+                term.write_str(&" ".repeat(term.width().saturating_sub(line_width)))?;
             }
         }
 


### PR DESCRIPTION
The user progress template can exceed the terminal width, so we use a
`saturating_sub` when calculating padding spaces to clamp it at 0 in
this case.

fix https://github.com/console-rs/indicatif/issues/358