### PR TITLE
Pass force_draw into drawable()

### DIFF
--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -247,12 +247,12 @@ impl ProgressBar {
         let (draw_target, state) = (&mut state.draw_target, &state.state);
         let width = draw_target.width();
 
-        let mut drawable = match draw_target.drawable() {
+        let mut drawable = match draw_target.drawable(true) {
             Some(drawable) => drawable,
             None => return,
         };
 
-        let mut draw_state = drawable.state(true);
+        let mut draw_state = drawable.state();
         draw_state.move_cursor = false;
         draw_state.alignment = Default::default();
 
@@ -437,7 +437,7 @@ impl ProgressBar {
     /// ```
     pub fn suspend<F: FnOnce() -> R, R>(&self, f: F) -> R {
         let mut state = self.state.lock().unwrap();
-        if let Some(drawable) = state.draw_target.drawable() {
+        if let Some(drawable) = state.draw_target.drawable(true) {
             let _ = drawable.clear();
         }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -101,21 +101,22 @@ impl BarState {
         self.draw(true).ok();
     }
 
-    pub(crate) fn draw(&mut self, force_draw: bool) -> io::Result<()> {
+    pub(crate) fn draw(&mut self, mut force_draw: bool) -> io::Result<()> {
         // we can bail early if the draw target is hidden.
         if self.draw_target.is_hidden() {
             return Ok(());
         }
 
         let width = self.draw_target.width();
-        let mut drawable = match self.draw_target.drawable() {
+        force_draw |= self.state.is_finished();
+        let mut drawable = match self.draw_target.drawable(force_draw) {
             Some(drawable) => drawable,
             None => return Ok(()),
         };
 
         // `|| self.is_finished()` should not be needed here, but we used to always for draw for
         // finished progress bar, so it's kept as to not cause compatibility issues in weird cases.
-        let mut draw_state = drawable.state(force_draw || self.state.is_finished());
+        let mut draw_state = drawable.state();
 
         if self.state.should_render() {
             self.state


### PR DESCRIPTION
This is a regression from my work on drawing into draw states. Specifically, before 57e6ee282d5dd71f7846bd28e3f0369fd3f6d452 `force_draw` was passed in as part of the `ProgressDrawState`, but after that commit it was no longer handled correctly. Fixes #368.

@chris-laplante I think this is pretty much what you were suggesting, right? If you want to give it a quick look that would be great.