### PR TITLE
Do not use boxcar windowing when displaying the final total of the speed

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -240,11 +240,15 @@ impl ProgressState {
 
     /// The number of steps per second
     pub(crate) fn per_sec(&self) -> f64 {
-        let per_sec = 1.0 / self.est.seconds_per_step();
-        if per_sec.is_nan() {
-            0.0
+        if matches!(&self.status, Status::InProgress) {
+            let per_sec = 1.0 / self.est.seconds_per_step();
+            if per_sec.is_nan() {
+                0.0
+            } else {
+                per_sec
+            }
         } else {
-            per_sec
+            self.len as f64 / self.started.elapsed().as_secs_f64()
         }
     }
 


### PR DESCRIPTION
This is especially relevant when speed varies a lot. Then confusing things like this https://github.com/probe-rs/probe-rs/issues/801 can happen. This is unfortunately only barely, if at all, visible in the examples as speed, whilst varying a little, is steady.