### PR TITLE
Fix Ticker issue #397

### DIFF
--- a/src/in_memory.rs
+++ b/src/in_memory.rs
@@ -41,6 +41,7 @@ impl InMemoryTerm {
             .into_iter()
             .rev()
             .skip_while(|line| line.is_empty())
+            .map(|line| line.trim_end().to_string())
             .collect();
 
         // Un-reverse the rows and join them up with newlines

--- a/src/state.rs
+++ b/src/state.rs
@@ -309,6 +309,7 @@ impl Ticker {
             self.interval = interval;
             state.draw(false, Instant::now()).ok();
             drop(state); // Don't forget to drop the lock before sleeping
+            drop(arc); // Also need to drop Arc otherwise BarState won't be dropped
             thread::sleep(self.interval);
         }
     }

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -4,6 +4,7 @@ use indicatif::{
     InMemoryTerm, MultiProgress, ProgressBar, ProgressDrawTarget, ProgressFinish, ProgressStyle,
     TermLike,
 };
+use std::time::Duration;
 
 #[test]
 fn basic_progress_bar() {
@@ -240,5 +241,30 @@ And so is this
 
 Another line printed"#
             .trim()
+    );
+}
+
+#[test]
+fn ticker_drop() {
+    let in_mem = InMemoryTerm::new(10, 80);
+    let mp =
+        MultiProgress::with_draw_target(ProgressDrawTarget::term_like(Box::new(in_mem.clone())));
+
+    let mut spinner: Option<ProgressBar> = None;
+
+    for i in 0..5 {
+        let new_spinner = mp.add(
+            ProgressBar::new_spinner()
+                .with_finish(ProgressFinish::AndLeave)
+                .with_message(format!("doing stuff {}", i)),
+        );
+        new_spinner.enable_steady_tick(Duration::from_millis(50));
+        spinner.replace(new_spinner);
+    }
+
+    drop(spinner);
+    assert_eq!(
+        in_mem.contents(),
+        "  doing stuff 0\n  doing stuff 1\n  doing stuff 2\n  doing stuff 3\n  doing stuff 4"
     );
 }


### PR DESCRIPTION
I think there are two parts to #397:

1. In addition to dropping the `MutexGuard<BarState>`, we also need to drop the `Arc<Mutex<BarState>>`, otherwise the reference count will never drop to 0 while the thread sleeps. The main thread will exit, but the destructor (on the `Ticker` thread's stack) will not run.
2. Even with (1) in place (which seems to fix the issue), I think to be safe we also need to `join` the `JoinHandle`. Trouble is I am not yet sure where to put the `join`. It can't go in the `Drop` impl for `BarState` since then the thread would probably try to join itself. Perhaps we need to move the ticker state into an `Arc<Mutex<Option<TickerState>>>` in `ProgressBar` or something. Then we could rewrite `Ticker::run` to use, e.g. [`CondVar::wait_timeout`](https://doc.rust-lang.org/stable/std/sync/struct.Condvar.html#method.wait_timeout) instead of `thread::sleep(self.interval)`.

So more experimenting is necessary.