### PR TITLE
Update tokio example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ exclude = ["screenshots/*"]
 
 [dependencies]
 console = { version = "0.15", default-features = false, features = ["ansi-parsing"] }
+futures = "0.3.21"
 number_prefix = "0.4"
 rayon = { version = "1.1", optional = true }
 tokio = { version = "1", optional = true, features = ["fs", "io-util"] }
@@ -24,7 +25,7 @@ vt100 = { version = "0.15.1", optional = true }
 once_cell = "1"
 rand = "0.8"
 structopt = "0.3"
-tokio = { version = "1", features = ["time", "rt"] }
+tokio = { version = "1", features = ["macros", "time", "rt", "rt-multi-thread"] }
 
 [features]
 default = ["unicode-width", "console/unicode-width"]

--- a/examples/tokio.rs
+++ b/examples/tokio.rs
@@ -1,33 +1,60 @@
-use indicatif::ProgressBar;
-use std::time::Duration;
-use tokio::runtime;
-use tokio::time::interval;
+//! Example of asynchronous multiple progress bars.
+//!
+//! The child bars are added to the main one. Once a child bar is complete it
+//! gets removed from the rendering and the main bar advances by 1 unit.
+//!
+//! Run with
+//!
+//! ```not_rust
+//! cargo run --example tokio
+//! ```
+//!
+use futures::stream::{self, StreamExt};
+use rand::{thread_rng, Rng};
+use std::sync::Arc;
+use tokio::time::{sleep, Duration};
 
-fn main() {
-    // Plain progress bar, totaling 1024 steps.
-    let steps = 1024;
-    let pb = ProgressBar::new(steps);
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 
-    // Stream of events, triggering every 5ms.
-    let rt = runtime::Builder::new_current_thread()
-        .enable_time()
-        .build()
-        .expect("failed to create runtime");
+const MAX_CONCURRENT_ITEMS: usize = 5;
 
-    // Future computation which runs for `steps` interval events,
-    // incrementing one step of the progress bar each time.
-    let future = async {
-        let mut intv = interval(Duration::from_millis(5));
+#[tokio::main]
+async fn main() {
+    // Creates a new multi-progress object.
+    let multi = Arc::new(MultiProgress::new());
+    let style = ProgressStyle::with_template("{bar:40.green/yellow} {pos:>7}/{len:7}").unwrap();
 
-        for _ in 0..steps {
-            intv.tick().await;
-            pb.inc(1);
-        }
-    };
+    // Create the main progress bar.
+    let mut rng = thread_rng();
+    let items = rng.gen_range(MAX_CONCURRENT_ITEMS..MAX_CONCURRENT_ITEMS * 3);
+    let main = Arc::new(multi.add(ProgressBar::new(items as u64).with_style(style.clone())));
+    main.tick();
 
-    // Drive the future to completion, blocking until done.
-    rt.block_on(future);
+    // Add the child progress bars.
+    let _pbs = stream::iter(0..items)
+        .map(|_i| add_bar(main.clone(), multi.clone()))
+        .buffer_unordered(MAX_CONCURRENT_ITEMS)
+        .collect::<Vec<_>>()
+        .await;
+    main.finish_with_message("done");
+}
 
-    // Mark the progress bar as finished.
-    pb.finish();
+async fn add_bar(main: Arc<ProgressBar>, multi: Arc<MultiProgress>) {
+    // Create a child bar and add it to the main one.
+    let mut rng = thread_rng();
+    let length: u64 = rng.gen_range(128..1024);
+    let sleep_ms: u64 = rng.gen_range(5..10);
+    let style = ProgressStyle::with_template("{bar:40.cyan/blue} {pos:>7}/{len:7}").unwrap();
+    let pb = multi.add(ProgressBar::new(length).with_style(style.clone()));
+
+    // Simulate some work.
+    for _ in 0..length {
+        pb.inc(1);
+        sleep(Duration::from_millis(sleep_ms)).await;
+    }
+    // Remove the bar once complete.
+    pb.finish_and_clear();
+
+    // Advance the main progress bar.
+    main.inc(1);
 }


### PR DESCRIPTION
Updates the tokio with an example where a main progress bar monitors child
progress bars started asynchronously.

This examples also remove the blocking call in the async function, an uses the
`#[tokio::main]` macro instead of initializing the runtime manually.
