### PR TITLE
Store length as an Option

### DIFF
--- a/examples/multi-tree-ext.rs
+++ b/examples/multi-tree-ext.rs
@@ -193,7 +193,7 @@ pub fn main() {
         ELEMENTS
             .iter()
             .map(|e| match e {
-                Elem::AddItem(item) => item.progress_bar.length(),
+                Elem::AddItem(item) => item.progress_bar.length().unwrap(),
                 Elem::RemoveItem(_) => 1,
             })
             .sum(),
@@ -230,15 +230,14 @@ pub fn main() {
                     let item = items.remove(*index);
                     let pb = &item.progress_bar;
                     mp2.remove(pb);
-                    pb_main.inc(pb.length() - pb.position());
+                    pb_main.inc(pb.length().unwrap() - pb.position());
                 }
             },
             Action::IncProgressBar(item_idx) => {
                 let item = &items[item_idx];
                 item.progress_bar.inc(1);
                 let pos = item.progress_bar.position();
-                let len = item.progress_bar.length();
-                if pos >= len {
+                if pos >= item.progress_bar.length().unwrap() {
                     item.progress_bar.set_style(sty_fin.clone());
                     item.progress_bar.finish_with_message(format!(
                         "{} {}",
@@ -262,8 +261,7 @@ fn get_action<'a>(rng: &'a mut dyn RngCore, items: &[&Item]) -> Action {
         .enumerate()
         .filter(|(_, item)| {
             let pos = item.progress_bar.position();
-            let len = item.progress_bar.length();
-            pos < len
+            pos < item.progress_bar.length().unwrap()
         })
         .map(|(idx, _)| idx)
         .collect::<Vec<usize>>();

--- a/examples/multi-tree.rs
+++ b/examples/multi-tree.rs
@@ -90,7 +90,10 @@ fn main() {
     let sty_aux = ProgressStyle::with_template("{spinner:.green} {msg} {pos:>4}/{len:4}").unwrap();
 
     let pb_main = mp.add(ProgressBar::new(
-        ELEMENTS.iter().map(|e| e.progress_bar.length()).sum(),
+        ELEMENTS
+            .iter()
+            .map(|e| e.progress_bar.length().unwrap())
+            .sum(),
     ));
     pb_main.set_style(sty_main);
     for elem in ELEMENTS.iter() {
@@ -121,8 +124,7 @@ fn main() {
                     let elem = &tree.lock().unwrap()[el_idx];
                     elem.progress_bar.inc(1);
                     let pos = elem.progress_bar.position();
-                    let len = elem.progress_bar.length();
-                    if pos >= len {
+                    if pos >= elem.progress_bar.length().unwrap() {
                         elem.progress_bar.finish_with_message(format!(
                             "{}{} {}",
                             "  ".repeat(elem.indent),
@@ -155,7 +157,7 @@ fn get_action<'a>(rng: &'a mut dyn RngCore, tree: &Mutex<Vec<&Elem>>) -> Option<
         .iter()
         .map(|e| {
             let pos = e.progress_bar.position();
-            let len = e.progress_bar.length();
+            let len = e.progress_bar.length().unwrap();
             len - pos
         })
         .sum::<u64>();
@@ -176,7 +178,7 @@ fn get_action<'a>(rng: &'a mut dyn RngCore, tree: &Mutex<Vec<&Elem>>) -> Option<
                 let l = (k % list_len) as usize;
                 let pos = list[l].progress_bar.position();
                 let len = list[l].progress_bar.length();
-                if pos < len {
+                if pos < len.unwrap() {
                     return Some(Action::IncProgressBar(l));
                 }
             }

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -34,7 +34,7 @@ impl ProgressBar {
     /// a second. To change the refresh rate, set the draw target to one with a different refresh
     /// rate.
     pub fn new(len: u64) -> ProgressBar {
-        ProgressBar::with_draw_target(len, ProgressDrawTarget::stderr())
+        ProgressBar::with_draw_target(Some(len), ProgressDrawTarget::stderr())
     }
 
     /// Creates a completely hidden progress bar
@@ -42,11 +42,11 @@ impl ProgressBar {
     /// This progress bar still responds to API changes but it does not have a length or render in
     /// any way.
     pub fn hidden() -> ProgressBar {
-        ProgressBar::with_draw_target(!0, ProgressDrawTarget::hidden())
+        ProgressBar::with_draw_target(None, ProgressDrawTarget::hidden())
     }
 
     /// Creates a new progress bar with a given length and draw target
-    pub fn with_draw_target(len: u64, draw_target: ProgressDrawTarget) -> ProgressBar {
+    pub fn with_draw_target(len: Option<u64>, draw_target: ProgressDrawTarget) -> ProgressBar {
         let pos = Arc::new(AtomicPosition::default());
         ProgressBar {
             state: Arc::new(Mutex::new(BarState::new(len, draw_target, pos.clone()))),
@@ -114,7 +114,7 @@ impl ProgressBar {
     ///
     /// This spinner by default draws directly to stderr. This adds the default spinner style to it.
     pub fn new_spinner() -> ProgressBar {
-        let rv = ProgressBar::new(!0);
+        let rv = ProgressBar::with_draw_target(None, ProgressDrawTarget::stderr());
         rv.set_style(ProgressStyle::default_spinner());
         rv
     }
@@ -449,7 +449,7 @@ impl ProgressBar {
     }
 
     /// Returns the current length
-    pub fn length(&self) -> u64 {
+    pub fn length(&self) -> Option<u64> {
         self.state().state.len()
     }
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -221,7 +221,9 @@ impl ProgressStyle {
         let mut cur = String::new();
         let mut buf = String::new();
         let mut wide = None;
-        let (pos, len) = (state.pos(), state.len());
+
+        let pos = state.pos();
+        let len = state.len().unwrap_or(pos);
         for part in &self.template.parts {
             match part {
                 TemplatePart::Placeholder {
@@ -682,7 +684,7 @@ mod tests {
     fn test_expand_template() {
         const WIDTH: u16 = 80;
         let pos = Arc::new(AtomicPosition::default());
-        let state = ProgressState::new(10, pos);
+        let state = ProgressState::new(Some(10), pos);
         let mut buf = Vec::new();
 
         let mut style = ProgressStyle::default_bar();
@@ -706,7 +708,7 @@ mod tests {
 
         const WIDTH: u16 = 80;
         let pos = Arc::new(AtomicPosition::default());
-        let state = ProgressState::new(10, pos);
+        let state = ProgressState::new(Some(10), pos);
         let mut buf = Vec::new();
 
         let mut style = ProgressStyle::default_bar();
@@ -736,7 +738,7 @@ mod tests {
     fn align_truncation() {
         const WIDTH: u16 = 10;
         let pos = Arc::new(AtomicPosition::default());
-        let state = ProgressState::new(10, pos);
+        let state = ProgressState::new(Some(10), pos);
         let mut buf = Vec::new();
 
         let mut style = ProgressStyle::with_template("{wide_msg}").unwrap();

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -8,8 +8,10 @@ use indicatif::{
 #[test]
 fn basic_progress_bar() {
     let in_mem = InMemoryTerm::new(10, 80);
-    let pb =
-        ProgressBar::with_draw_target(10, ProgressDrawTarget::term_like(Box::new(in_mem.clone())));
+    let pb = ProgressBar::with_draw_target(
+        Some(10),
+        ProgressDrawTarget::term_like(Box::new(in_mem.clone())),
+    );
 
     assert_eq!(in_mem.contents(), String::new());
 
@@ -36,16 +38,16 @@ fn basic_progress_bar() {
 fn progress_bar_builder_method_order() {
     let in_mem = InMemoryTerm::new(10, 80);
     // Test that `with_style` doesn't overwrite the message or prefix
-    let pb =
-        ProgressBar::with_draw_target(10, ProgressDrawTarget::term_like(Box::new(in_mem.clone())))
-            .with_message("crate")
-            .with_prefix("Downloading")
-            .with_style(
-                ProgressStyle::with_template(
-                    "{prefix:>12.cyan.bold} {msg}: {wide_bar} {pos}/{len}",
-                )
-                .unwrap(),
-            );
+    let pb = ProgressBar::with_draw_target(
+        Some(10),
+        ProgressDrawTarget::term_like(Box::new(in_mem.clone())),
+    )
+    .with_message("crate")
+    .with_prefix("Downloading")
+    .with_style(
+        ProgressStyle::with_template("{prefix:>12.cyan.bold} {msg}: {wide_bar} {pos}/{len}")
+            .unwrap(),
+    );
 
     assert_eq!(in_mem.contents(), String::new());
 


### PR DESCRIPTION
Previously we used a sentinel value of u64::MAX, which made it
harder to see what was going on or handle this case right.

Fixes #409.