### PR TITLE
Stateful Formatters

### DIFF
--- a/examples/download.rs
+++ b/examples/download.rs
@@ -1,8 +1,8 @@
-use std::cmp::min;
 use std::thread;
 use std::time::Duration;
+use std::{cmp::min, fmt::Write};
 
-use indicatif::{ProgressBar, ProgressStyle};
+use indicatif::{ProgressBar, ProgressState, ProgressStyle};
 
 fn main() {
     let mut downloaded = 0;
@@ -11,7 +11,7 @@ fn main() {
     let pb = ProgressBar::new(total_size);
     pb.set_style(ProgressStyle::with_template("{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {bytes}/{total_bytes} ({eta})")
         .unwrap()
-        .with_key("eta", |state| format!("{:.1}s", state.eta().as_secs_f64()))
+        .with_key("eta", |state: &ProgressState, w: &mut dyn Write| write!(w, "{:.1}s", state.eta().as_secs_f64()).unwrap())
         .progress_chars("#>-"));
 
     while downloaded < total_size {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,7 +225,7 @@ mod progress_bar;
 #[cfg(feature = "rayon")]
 mod rayon;
 mod state;
-mod style;
+pub mod style;
 mod term_like;
 
 pub use crate::draw_target::ProgressDrawTarget;

--- a/src/state.rs
+++ b/src/state.rs
@@ -75,6 +75,11 @@ impl BarState {
         if let Reset::All = mode {
             self.state.pos.reset(now);
             self.state.status = Status::InProgress;
+
+            for (_, tracker) in self.style.format_map.iter_mut() {
+                tracker.reset(&self.state, now);
+            }
+
             let _ = self.draw(false, now);
         }
     }
@@ -117,6 +122,10 @@ impl BarState {
         let pos = self.state.pos.pos.load(Ordering::Relaxed);
         self.state.est.record(pos, now);
         let _ = self.draw(false, now);
+
+        for (_, tracker) in self.style.format_map.iter_mut() {
+            tracker.tick(&self.state, now);
+        }
     }
 
     pub(crate) fn println(&mut self, now: Instant, msg: &str) {


### PR DESCRIPTION
Very much a janky WIP, and some of the objects I introduced could use better naming though I avoided doing so in the interest of retaining compatibility with existing code. Haven't tested this against older rustc, but as of my current rustc version (latest stable) there are no lints from either regular check or clippy. But let me know if this seems like an ok direction and I'll revise it further.

~~Somewhen I'll modify that example to show what a more bumpy file transfer looks like, and the advantage of averaging it by the method I used.~~ done