### PR TITLE
add naive test for ticker termination

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ exclude = ["screenshots/*"]
 [dependencies]
 console = { version = "0.15", default-features = false, features = ["ansi-parsing"] }
 number_prefix = "0.4"
+lazy_static = "1.4.0"
 rayon = { version = "1.1", optional = true }
 tokio = { version = "1", optional = true, features = ["fs", "io-util"] }
 unicode-segmentation = { version = "1", optional = true }


### PR DESCRIPTION
I'd say if we can get this test to pass, then we can ensure that `Ticker` is behaving properly on `ProgressBar` drop.