### PR TITLE
Make sure the ticker thread can die gracefully

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ exclude = ["screenshots/*"]
 [dependencies]
 console = { version = "0.15", default-features = false, features = ["ansi-parsing"] }
 number_prefix = "0.4"
+once_cell = "1"
 rayon = { version = "1.1", optional = true }
 tokio = { version = "1", optional = true, features = ["fs", "io-util"] }
 unicode-segmentation = { version = "1", optional = true }
@@ -21,7 +22,6 @@ unicode-width = { version = "0.1", optional = true }
 vt100 = { version = "0.15.1", optional = true }
 
 [dev-dependencies]
-once_cell = "1"
 rand = "0.8"
 structopt = "0.3"
 tokio = { version = "1", features = ["time", "rt"] }

--- a/examples/long-spinner.rs
+++ b/examples/long-spinner.rs
@@ -1,7 +1,7 @@
 use std::thread;
 use std::time::Duration;
 
-use indicatif::{ProgressBar, ProgressStyle};
+use indicatif::{ProgressBar, ProgressStyle, TICKER_BARRIER};
 
 fn main() {
     let pb = ProgressBar::new_spinner();
@@ -22,6 +22,15 @@ fn main() {
             ]),
     );
     pb.set_message("Calculating...");
-    thread::sleep(Duration::from_secs(5));
-    pb.finish_with_message("Done");
+
+    // Wait long enough for the `Ticker` to make it inside the loop and to the first barrier.
+
+    // Note: if you uncomment this sleep, the program will deadlock because the drop(pb)
+    // below will cause the ticker loop to never run, so a call to TICKER_BARRIER.wait()
+    // will never be made in Ticker.
+    thread::sleep(Duration::from_millis(200));
+
+    drop(pb);
+
+    TICKER_BARRIER.wait();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,3 +243,5 @@ pub use crate::term_like::TermLike;
 
 #[cfg(feature = "rayon")]
 pub use crate::rayon::ParallelProgressIterator;
+
+pub use crate::state::TICKER_BARRIER;


### PR DESCRIPTION
Fixes #416. See also previous discussion in #417 and #421.

Thanks for working on this test! I reworked the test to avoid adding overhead outside running tests and reuse the once_cell dev-dependency (which has a nicer API anyway) instead of adding lazy_static.

I also weakened the guarantee from your test: instead of asserting that the ticker terminates, I think it's strong enough to assert that the ticker is sleeping. At that point, it always only has access to a `Weak`, so if all strong references to the underlying data have been dropped, the ticker will fail to upgrade and terminate cleanly. I implemented this by changing your `AtomicBool` to indicate whether the ticker is running, setting to `false` when the ticker goes to sleep and `true` when it wakes up again.

This allows us to fix this issue by simply moving the `Drop` impl from `BarState` to `ProgressBarInner`, having it lock the `Mutex` during drop. This means that:

* If the ticker currently holds the lock, the `Drop` impl will wait for the ticker to go to sleep.
* If the ticker tries to wake up while the `Drop` code is running, it will need to wait until `Drop` drops the lock.
* If the ticker acquires the lock after `Drop` is run, it will find that `state.state.is_finished()` and terminate cleanly.
* If the ticker wakes up after all strong references to the `ProgressBarInner` have dropped, it will terminate cleanly.

I think that covers everything?