### PR TITLE
Remove rustfmt config again

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,0 @@
-imports_granularity = "Module"
-group_imports = "StdExternalCrate"


### PR DESCRIPTION
This contains unstable options, which results in warnings when running
stable rustfmt. That doesn't seem like a good experience to me.

@chris-laplante what do you think? IMO this is a little too ugly (for outside contributors, too) to keep like this. Alternatives:

* We can enforce nightly rustfmt in CI, but sucks if local rustfmt is different from CI
* We could ignore rustfmt.toml, so you can keep it around and I'll review manually?