### PR TITLE
Implement multi-line progress message support

### DIFF
--- a/src/style.rs
+++ b/src/style.rs
@@ -359,23 +359,30 @@ impl ProgressStyle {
                     }
                 }
                 TemplatePart::Literal(s) => cur.push_str(s.expanded()),
-                TemplatePart::NewLine => lines.push(match wide {
-                    Some(inner) => {
-                        inner.expand(mem::take(&mut cur), self, state, &mut buf, target_width)
-                    }
-                    None => mem::take(&mut cur),
-                }),
+                TemplatePart::NewLine => {
+                    self.push_line(lines, &mut cur, state, &mut buf, target_width, &wide)
+                }
             }
         }
 
         if !cur.is_empty() {
-            lines.push(match wide {
-                Some(inner) => {
-                    inner.expand(mem::take(&mut cur), self, state, &mut buf, target_width)
-                }
-                None => mem::take(&mut cur),
-            })
+            self.push_line(lines, &mut cur, state, &mut buf, target_width, &wide);
         }
+    }
+
+    fn push_line(
+        &self,
+        lines: &mut Vec<String>,
+        cur: &mut String,
+        state: &ProgressState,
+        buf: &mut String,
+        target_width: u16,
+        wide: &Option<WideElement>,
+    ) {
+        lines.push(match wide {
+            Some(inner) => inner.expand(mem::take(cur), self, state, buf, target_width),
+            None => mem::take(cur),
+        });
     }
 }
 


### PR DESCRIPTION
This PR adds support for multi-line progress messages, following #442.

The changes mostly update the drawing functions to split progress messages before counting them, so that the correct number of lines are cleared when they are redrawn. I'm not sure I 100% understood how orphan lines work, so I'd appreciate if someone could take a closer look at how I handle them.

The existing examples all run as they did previously, and I've added a new example (`multi-log`) showing the style I was trying to implement when I opened the issue.

One thing I noticed is that calling `clear` on a multiline progress doesn't always seem to clear all progress messages, a random amount stays on the screen even when a message is printed afterwards. I first thought that I introduced that bug, but switching back to main it still appeared in the examples I tried (`yarnish` and `multi`). Is this a known bug?