### PR TITLE
leverage GenerationalTokenList to simplify multi code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ exclude = ["screenshots/*"]
 
 [dependencies]
 console = { version = "0.15", default-features = false, features = ["ansi-parsing"] }
+generational_token_list = { version = "0.1.5", features = ["iter-mut"] }
 number_prefix = "0.4"
 rayon = { version = "1.1", optional = true }
 tokio = { version = "1", optional = true, features = ["fs", "io-util"] }

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard, Weak};
 use std::time::{Duration, Instant};
 use std::{fmt, io, mem, thread};
+use generational_token_list::ItemToken;
 
 #[cfg(test)]
 use once_cell::sync::Lazy;
@@ -512,9 +513,9 @@ impl ProgressBar {
         self.state().state.elapsed()
     }
 
-    /// Index in the `MultiState`
-    pub(crate) fn index(&self) -> Option<usize> {
-        self.state().draw_target.remote().map(|(_, idx)| idx)
+    /// Token in the `MultiState`
+    pub(crate) fn token(&self) -> Option<ItemToken> {
+        self.state().draw_target.remote().map(|(_, token)| token)
     }
 
     #[inline]


### PR DESCRIPTION
I _did_ have to enable the use of 'unsafe' code in `GenerationalTokenList` in order to use `iter_mut`. Nothing is reported by `MIRIFLAGS=-Zmiri-disable-isolation cargo miri test`. 

I'm fairly confident the code is correct. Basically, I think that as long as the `GenerationalTokenList` maintains the linked list properly (no cycles) nothing bad can happen. 

Still, I understand if you are reticent to accept the unsafe code. I thought I'd present what I have here anyway :).