### PR TITLE
HumanFloatCount for per_sec

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -34,6 +34,10 @@ pub struct BinaryBytes(pub u64);
 #[derive(Debug)]
 pub struct HumanCount(pub u64);
 
+/// Formats counts for human readability using commas for floats
+#[derive(Debug)]
+pub struct HumanFloatCount(pub f64);
+
 impl fmt::Display for FormattedDuration {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut t = self.0.as_secs();
@@ -140,6 +144,33 @@ impl fmt::Display for HumanCount {
             f.write_char(c)?;
             if pos > 0 && pos % 3 == 0 {
                 f.write_char(',')?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for HumanFloatCount {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use fmt::Write;
+
+        let num = self.0.to_string();
+        let (int_part, frac_part) = match num.split_once('.') {
+            Some((int_str, fract_str)) => (int_str.to_string(), fract_str),
+            None => (self.0.trunc().to_string(), ""),
+        };
+        let len = int_part.len();
+        for (idx, c) in int_part.chars().enumerate() {
+            let pos = len - idx - 1;
+            f.write_char(c)?;
+            if pos > 0 && pos % 3 == 0 {
+                f.write_char(',')?;
+            }
+        }
+        if !frac_part.is_empty() {
+            f.write_char('.')?;
+            for digit_char in frac_part.chars().take(4) {
+                f.write_char(digit_char)?;
             }
         }
         Ok(())
@@ -281,5 +312,17 @@ mod tests {
         assert_eq!("7,654", format!("{}", HumanCount(7654)));
         assert_eq!("12,345", format!("{}", HumanCount(12345)));
         assert_eq!("1,234,567,890", format!("{}", HumanCount(1234567890)));
+    }
+
+    #[test]
+    fn human_float_count() {
+        assert_eq!("42", format!("{}", HumanFloatCount(42.0)));
+        assert_eq!("7,654", format!("{}", HumanFloatCount(7654.0)));
+        assert_eq!("12,345", format!("{}", HumanFloatCount(12345.0)));
+        assert_eq!("1,234,567,890", format!("{}", HumanFloatCount(1234567890.0)));
+        assert_eq!("42.5", format!("{}", HumanFloatCount(42.5)));
+        assert_eq!("7,654.321", format!("{}", HumanFloatCount(7654.321)));
+        assert_eq!("12,345.6789", format!("{}", HumanFloatCount(12345.6789)));
+        assert_eq!("1,234,567,890.1234", format!("{}", HumanFloatCount(1234567890.123456)));
     }
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -170,9 +170,7 @@ impl fmt::Display for HumanFloatCount {
         let frac_trimmed = frac_part.trim_end_matches('0');
         if !frac_trimmed.is_empty() {
             f.write_char('.')?;
-            for digit_char in frac_trimmed.chars().take(4) {
-                f.write_char(digit_char)?;
-            }
+            f.write_str(frac_trimmed)?;
         }
         Ok(())
     }

--- a/src/format.rs
+++ b/src/format.rs
@@ -154,7 +154,7 @@ impl fmt::Display for HumanFloatCount {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use fmt::Write;
 
-        let num = self.0.to_string();
+        let num = format!("{:.4}", self.0);
         let (int_part, frac_part) = match num.split_once('.') {
             Some((int_str, fract_str)) => (int_str.to_string(), fract_str),
             None => (self.0.trunc().to_string(), ""),
@@ -167,9 +167,10 @@ impl fmt::Display for HumanFloatCount {
                 f.write_char(',')?;
             }
         }
-        if !frac_part.is_empty() {
+        let frac_trimmed = frac_part.trim_end_matches('0');
+        if !frac_trimmed.is_empty() {
             f.write_char('.')?;
-            for digit_char in frac_part.chars().take(4) {
+            for digit_char in frac_trimmed.chars().take(4) {
                 f.write_char(digit_char)?;
             }
         }
@@ -324,11 +325,18 @@ mod tests {
             format!("{}", HumanFloatCount(1234567890.0))
         );
         assert_eq!("42.5", format!("{}", HumanFloatCount(42.5)));
+        assert_eq!("42.5", format!("{}", HumanFloatCount(42.500012345)));
+        assert_eq!("42.502", format!("{}", HumanFloatCount(42.502012345)));
         assert_eq!("7,654.321", format!("{}", HumanFloatCount(7654.321)));
+        assert_eq!("7,654.321", format!("{}", HumanFloatCount(7654.3210123456)));
         assert_eq!("12,345.6789", format!("{}", HumanFloatCount(12345.6789)));
         assert_eq!(
+            "1,234,567,890.1235",
+            format!("{}", HumanFloatCount(1234567890.1234567))
+        );
+        assert_eq!(
             "1,234,567,890.1234",
-            format!("{}", HumanFloatCount(1234567890.123456))
+            format!("{}", HumanFloatCount(1234567890.1234321))
         );
     }
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -319,10 +319,16 @@ mod tests {
         assert_eq!("42", format!("{}", HumanFloatCount(42.0)));
         assert_eq!("7,654", format!("{}", HumanFloatCount(7654.0)));
         assert_eq!("12,345", format!("{}", HumanFloatCount(12345.0)));
-        assert_eq!("1,234,567,890", format!("{}", HumanFloatCount(1234567890.0)));
+        assert_eq!(
+            "1,234,567,890",
+            format!("{}", HumanFloatCount(1234567890.0))
+        );
         assert_eq!("42.5", format!("{}", HumanFloatCount(42.5)));
         assert_eq!("7,654.321", format!("{}", HumanFloatCount(7654.321)));
         assert_eq!("12,345.6789", format!("{}", HumanFloatCount(12345.6789)));
-        assert_eq!("1,234,567,890.1234", format!("{}", HumanFloatCount(1234567890.123456)));
+        assert_eq!(
+            "1,234,567,890.1234",
+            format!("{}", HumanFloatCount(1234567890.123456))
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,7 +201,7 @@
 //!
 //! ```rust
 //! # use std::time::Duration;
-//! use indicatif::{HumanBytes, HumanCount, HumanDuration, HumanFloatCount      };
+//! use indicatif::{HumanBytes, HumanCount, HumanDuration, HumanFloatCount};
 //!
 //! assert_eq!("3.00 MiB", HumanBytes(3*1024*1024).to_string());
 //! assert_eq!("8 seconds", HumanDuration(Duration::from_secs(8)).to_string());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,7 +206,7 @@
 //! assert_eq!("3.00 MiB", HumanBytes(3*1024*1024).to_string());
 //! assert_eq!("8 seconds", HumanDuration(Duration::from_secs(8)).to_string());
 //! assert_eq!("33,857,009", HumanCount(33857009).to_string());
-//! assert_eq!("33,857,009.1234", HumanFloatCount(33857009.123456).to_string());
+//! assert_eq!("33,857,009.1235", HumanFloatCount(33857009.123456).to_string());
 //! ```
 //!
 //! # Feature Flags

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@
 //!   * [`BinaryBytes`](struct.BinaryBytes.html) for formatting bytes using ISO/IEC prefixes
 //!   * [`HumanDuration`](struct.HumanDuration.html) for formatting durations
 //!   * [`HumanCount`](struct.HumanCount.html) for formatting large counts
+//!   * [`HumanFloatCount`](struct.HumanFloatCount.html) for formatting large float counts
 //!
 //! # Progress Bars and Spinners
 //!
@@ -200,11 +201,12 @@
 //!
 //! ```rust
 //! # use std::time::Duration;
-//! use indicatif::{HumanBytes, HumanCount, HumanDuration};
+//! use indicatif::{HumanBytes, HumanCount, HumanDuration, HumanFloatCount      };
 //!
 //! assert_eq!("3.00 MiB", HumanBytes(3*1024*1024).to_string());
 //! assert_eq!("8 seconds", HumanDuration(Duration::from_secs(8)).to_string());
 //! assert_eq!("33,857,009", HumanCount(33857009).to_string());
+//! assert_eq!("33,857,009.1234", HumanFloatCount(33857009.123456).to_string());
 //! ```
 //!
 //! # Feature Flags
@@ -230,7 +232,7 @@ mod term_like;
 
 pub use crate::draw_target::ProgressDrawTarget;
 pub use crate::format::{
-    BinaryBytes, DecimalBytes, FormattedDuration, HumanBytes, HumanCount, HumanDuration,
+    BinaryBytes, DecimalBytes, FormattedDuration, HumanBytes, HumanCount, HumanDuration, HumanFloatCount,
 };
 #[cfg(feature = "in_memory")]
 pub use crate::in_memory::InMemoryTerm;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,7 +232,8 @@ mod term_like;
 
 pub use crate::draw_target::ProgressDrawTarget;
 pub use crate::format::{
-    BinaryBytes, DecimalBytes, FormattedDuration, HumanBytes, HumanCount, HumanDuration, HumanFloatCount,
+    BinaryBytes, DecimalBytes, FormattedDuration, HumanBytes, HumanCount, HumanDuration,
+    HumanFloatCount,
 };
 #[cfg(feature = "in_memory")]
 pub use crate::in_memory::InMemoryTerm;

--- a/src/style.rs
+++ b/src/style.rs
@@ -8,7 +8,8 @@ use console::{measure_text_width, Style};
 use unicode_segmentation::UnicodeSegmentation;
 
 use crate::format::{
-    BinaryBytes, DecimalBytes, FormattedDuration, HumanBytes, HumanCount, HumanFloatCount, HumanDuration,
+    BinaryBytes, DecimalBytes, FormattedDuration, HumanBytes, HumanCount, HumanDuration,
+    HumanFloatCount,
 };
 use crate::state::{ProgressState, TabExpandedString, DEFAULT_TAB_WIDTH};
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -8,7 +8,7 @@ use console::{measure_text_width, Style};
 use unicode_segmentation::UnicodeSegmentation;
 
 use crate::format::{
-    BinaryBytes, DecimalBytes, FormattedDuration, HumanBytes, HumanCount, HumanDuration,
+    BinaryBytes, DecimalBytes, FormattedDuration, HumanBytes, HumanCount, HumanFloatCount, HumanDuration,
 };
 use crate::state::{ProgressState, TabExpandedString, DEFAULT_TAB_WIDTH};
 
@@ -300,7 +300,7 @@ impl ProgressStyle {
                                 .write_fmt(format_args!("{:#}", HumanDuration(state.elapsed())))
                                 .unwrap(),
                             "per_sec" => buf
-                                .write_fmt(format_args!("{:.4}/s", state.per_sec()))
+                                .write_fmt(format_args!("{}/s", HumanFloatCount(state.per_sec())))
                                 .unwrap(),
                             "bytes_per_sec" => buf
                                 .write_fmt(format_args!("{}/s", HumanBytes(state.per_sec() as u64)))


### PR DESCRIPTION
@djc here's my attempt to resolve #392.

`HumanFloatCount` largely mimics `HumanCount` with the exception that it accepts f64, and truncates the fractional part at 4 decimal places.  If the float is a whole number, it doesn't add ".0" to the end.

```rust
    #[test]
    fn human_float_count() {
        assert_eq!("42", format!("{}", HumanFloatCount(42.0)));
        assert_eq!("7,654", format!("{}", HumanFloatCount(7654.0)));
        assert_eq!("12,345", format!("{}", HumanFloatCount(12345.0)));
        assert_eq!(
            "1,234,567,890",
            format!("{}", HumanFloatCount(1234567890.0))
        );
        assert_eq!("42.5", format!("{}", HumanFloatCount(42.5)));
        assert_eq!("7,654.321", format!("{}", HumanFloatCount(7654.321)));
        assert_eq!("12,345.6789", format!("{}", HumanFloatCount(12345.6789)));
        assert_eq!(
            "1,234,567,890.1234",
            format!("{}", HumanFloatCount(1234567890.123456))
        );
    }
``` 

`per_sec` uses it, so instead of

`210879.6613/s`, you'd get `210,879.6613/s`
