### PR TITLE
Fix unicode-width feature spelling

### DIFF
--- a/src/style.rs
+++ b/src/style.rs
@@ -35,12 +35,12 @@ fn segment(s: &str) -> Vec<Box<str>> {
     s.chars().map(|x| x.to_string().into()).collect()
 }
 
-#[cfg(feature = "unicode_width")]
+#[cfg(feature = "unicode-width")]
 fn measure(s: &str) -> usize {
     unicode_width::UnicodeWidthStr::width(s)
 }
 
-#[cfg(not(feature = "unicode_width"))]
+#[cfg(not(feature = "unicode-width"))]
 fn measure(s: &str) -> usize {
     s.chars().count()
 }


### PR DESCRIPTION
Misspelled the feature with an underscore instead of dash while refactoring in https://github.com/console-rs/indicatif/commit/d7851c7a467313571d71133b1729af9c5dd3b2ae.

(This feature is actually enabled by default now.)

Fixes #455.