### PR TITLE
Only tick if the ticker is disabled

### DIFF
--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -191,9 +191,13 @@ impl ProgressBar {
     ///
     /// This automatically happens on any other change to a progress bar.
     pub fn tick(&self) {
+        self.tick_inner(Instant::now());
+    }
+
+    fn tick_inner(&self, now: Instant) {
         // Only tick if a `Ticker` isn't installed
         if self.ticker.lock().unwrap().is_none() {
-            self.state().tick(Instant::now())
+            self.state().tick(now)
         }
     }
 
@@ -201,8 +205,8 @@ impl ProgressBar {
     pub fn inc(&self, delta: u64) {
         self.pos.inc(delta);
         let now = Instant::now();
-        if self.pos.allow(now) && self.ticker.lock().unwrap().is_none() {
-            self.state().tick(now);
+        if self.pos.allow(now) {
+            self.tick_inner(now);
         }
     }
 
@@ -241,8 +245,8 @@ impl ProgressBar {
     pub fn set_position(&self, pos: u64) {
         self.pos.set(pos);
         let now = Instant::now();
-        if self.pos.allow(now) && self.ticker.lock().unwrap().is_none() {
-            self.state().tick(now);
+        if self.pos.allow(now) {
+            self.tick_inner(now);
         }
     }
 

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -201,7 +201,7 @@ impl ProgressBar {
     pub fn inc(&self, delta: u64) {
         self.pos.inc(delta);
         let now = Instant::now();
-        if self.pos.allow(now) {
+        if self.pos.allow(now) && self.ticker.lock().unwrap().is_none() {
             self.state().tick(now);
         }
     }
@@ -233,14 +233,15 @@ impl ProgressBar {
 
     /// Update the `ProgressBar`'s inner [`ProgressState`]
     pub fn update(&self, f: impl FnOnce(&mut ProgressState)) {
-        self.state().update(Instant::now(), f)
+        self.state()
+            .update(Instant::now(), f, self.ticker.lock().unwrap().is_none())
     }
 
     /// Sets the position of the progress bar
     pub fn set_position(&self, pos: u64) {
         self.pos.set(pos);
         let now = Instant::now();
-        if self.pos.allow(now) {
+        if self.pos.allow(now) && self.ticker.lock().unwrap().is_none() {
             self.state().tick(now);
         }
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -84,9 +84,11 @@ impl BarState {
         }
     }
 
-    pub(crate) fn update(&mut self, now: Instant, f: impl FnOnce(&mut ProgressState)) {
+    pub(crate) fn update(&mut self, now: Instant, f: impl FnOnce(&mut ProgressState), tick: bool) {
         f(&mut self.state);
-        self.tick(now);
+        if tick {
+            self.tick(now);
+        }
     }
 
     pub(crate) fn set_length(&mut self, now: Instant, len: u64) {

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -339,7 +339,7 @@ fn ticker_drop() {
                 .with_finish(ProgressFinish::AndLeave)
                 .with_message(format!("doing stuff {}", i)),
         );
-        new_spinner.enable_steady_tick(Duration::from_millis(50));
+        new_spinner.enable_steady_tick(Duration::from_millis(100));
         spinner.replace(new_spinner);
     }
 


### PR DESCRIPTION
Fix a regression from #417 to fix #457.

Of the 4 callers of `BarState::tick()`, changed three to no longer tick if the ticker is enabled:

* `ProgressBar::inc()`
* `ProgressBar::set_position()`
* `ProgressBar::update()`

The fourth is `ProgressBar::tick()`, which already only ticked if the ticker was disabled.