### PR TITLE
Rework zombie handling to fix #451 and #464

### DIFF
--- a/src/multi.rs
+++ b/src/multi.rs
@@ -1,6 +1,7 @@
 use std::fmt::{Debug, Formatter};
 use std::io;
 use std::sync::{Arc, Mutex, RwLock, Weak};
+use std::thread::panicking;
 use std::time::Instant;
 
 use crate::draw_target::{DrawState, DrawStateWrapper, ProgressDrawTarget};
@@ -208,6 +209,10 @@ impl MultiState {
         extra_lines: Option<Vec<String>>,
         now: Instant,
     ) -> io::Result<()> {
+        if panicking() {
+            return Ok(());
+        }
+
         // Reap all consecutive 'zombie' progress bars from head of the list
         let mut adjust = 0;
         while let Some(index) = self.ordering.first().copied() {

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -186,7 +186,8 @@ pub(crate) struct MultiState {
     move_cursor: bool,
     /// Controls how the multi progress is aligned if some of its progress bars get removed, default is `Top`
     alignment: MultiProgressAlignment,
-    /// Orphaned lines are carried over across draw operations
+    /// Lines to be drawn above everything else in the MultiProgress. These specifically come from
+    /// calling `ProgressBar::println` on a pb that is connected to a `MultiProgress`.
     orphan_lines: Vec<String>,
 }
 

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -289,10 +289,6 @@ impl ProgressBar {
         }
     }
 
-    pub(crate) fn weak_bar_state(&self) -> Weak<Mutex<BarState>> {
-        Arc::downgrade(&self.state)
-    }
-
     /// Resets the ETA calculation
     ///
     /// This can be useful if the progress bars made a large jump or was paused for a prolonged

--- a/src/state.rs
+++ b/src/state.rs
@@ -184,12 +184,17 @@ impl BarState {
 
 impl Drop for BarState {
     fn drop(&mut self) {
-        // Progress bar is already finished.  Do not need to do anything.
+        // Progress bar is already finished.  Do not need to do anything other than notify
+        // the `MultiProgress` that we're now a zombie.
         if self.state.is_finished() {
+            self.draw_target.mark_zombie();
             return;
         }
 
         self.finish_using_style(Instant::now(), self.on_finish.clone());
+
+        // Notify the `MultiProgress` that we're now a zombie.
+        self.draw_target.mark_zombie();
     }
 }
 

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -130,6 +130,14 @@ fn multi_progress_two_bars() {
     );
 
     drop(pb1);
+    assert_eq!(
+        in_mem.contents(),
+        r#"
+██████████████████████████████████████████████████████████████████████████ 10/10
+░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 0/5"#
+            .trim_start()
+    );
+
     drop(pb2);
 
     assert_eq!(
@@ -177,7 +185,24 @@ fn multi_progress() {
     );
 
     drop(pb1);
+    assert_eq!(
+        in_mem.contents(),
+        r#"
+██████████████████████████████████████████████████████████████████████████ 10/10
+░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 0/5
+░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 0/100"#
+            .trim_start()
+    );
+
     drop(pb2);
+    assert_eq!(
+        in_mem.contents(),
+        r#"
+██████████████████████████████████████████████████████████████████████████ 10/10
+░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 0/100"#
+            .trim_start()
+    );
+
     drop(pb3);
 
     assert_eq!(
@@ -397,7 +422,7 @@ fn multi_progress_prune_zombies() {
     drop(pb0);
 
     // Clear the screen
-    in_mem.reset();
+    mp.clear().unwrap();
 
     // Write a line that we expect to remain. This helps ensure the adjustment to last_line_count is
     // working as expected, and `MultiState` isn't erasing lines when it shouldn't.
@@ -467,9 +492,11 @@ fn multi_progress_prune_zombies_2() {
             .trim_start()
     );
 
-    in_mem.reset();
+    mp.clear().unwrap();
 
-    // Another sacrificial line we expect shouldn't be touched
+    assert_eq!(in_mem.contents(), "");
+
+    // A sacrificial line we expect shouldn't be touched
     in_mem.write_line("don't erase plz").unwrap();
 
     mp.println("Test friend :)").unwrap();
@@ -492,18 +519,34 @@ Test friend :)
     );
 
     drop(pb4);
+    assert_eq!(
+        in_mem.contents(),
+        r#"
+don't erase plz
+Test friend :)
+████████████████████████████████████████████████████████████████████████ 500/500"#
+            .trim_start()
+    );
 
-    in_mem.reset();
+    mp.clear().unwrap();
+    assert_eq!(in_mem.contents(), "don't erase plz\nTest friend :)");
+
     pb5.tick();
     assert_eq!(
         in_mem.contents(),
-        "░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 0/7"
+        r#"
+don't erase plz
+Test friend :)
+░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 0/7"#
+            .trim_start()
     );
 
     mp.println("not your friend, buddy").unwrap();
     assert_eq!(
         in_mem.contents(),
         r#"
+don't erase plz
+Test friend :)
 not your friend, buddy
 ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 0/7"#
             .trim_start()
@@ -513,18 +556,23 @@ not your friend, buddy
     assert_eq!(
         in_mem.contents(),
         r#"
+don't erase plz
+Test friend :)
 not your friend, buddy
 ██████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 1/7"#
             .trim_start()
     );
 
-    in_mem.reset();
+    mp.clear().unwrap();
     in_mem.write_line("don't erase me either").unwrap();
 
     pb5.inc(1);
     assert_eq!(
         in_mem.contents(),
         r#"
+don't erase plz
+Test friend :)
+not your friend, buddy
 don't erase me either
 █████████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 2/7"#
             .trim_start()
@@ -532,7 +580,15 @@ don't erase me either
 
     drop(pb5);
 
-    assert_eq!(in_mem.contents(), "don't erase me either");
+    assert_eq!(
+        in_mem.contents(),
+        r#"
+don't erase plz
+Test friend :)
+not your friend, buddy
+don't erase me either"#
+            .trim_start()
+    );
 }
 
 #[test]


### PR DESCRIPTION
This implements what I described [here](https://github.com/console-rs/indicatif/issues/451#issuecomment-1204409255) (except for the resetting upon `MultiProgress::clear` or `MultiProgress::suspend`). It is ugly because it is working around a double mutable borrow that occurs when you write the code in the "obvious" way:

```rust
fn clear(&mut self, now: Instant) -> io::Result<()> {
    match self.draw_target.drawable(true, now) {
        Some(drawable) => {
            if let Some(last_line_count) = self.draw_target.last_line_count() {
                *last_line_count += self.zombie_line_count;
                self.zombie_line_count = 0;
            }

            drawable.clear()
        }
        None => Ok(()),
    }
}
```

Ideally, only `MultiState`/`MultiProgress` would have to know anything about `zombie_line_count`, but I fear we may have to push it deeper into the hierarchy. I will do my best to find a way so that doesn't happen, though.