### PR TITLE
fix flaky render test by dropping old spinners

### DIFF
--- a/tests/render.rs
+++ b/tests/render.rs
@@ -334,6 +334,9 @@ fn ticker_drop() {
     let mut spinner: Option<ProgressBar> = None;
 
     for i in 0..5 {
+        let old_spinner = spinner.take();
+        drop(old_spinner);
+
         let new_spinner = mp.add(
             ProgressBar::new_spinner()
                 .with_finish(ProgressFinish::AndLeave)


### PR DESCRIPTION
Before this change, the ticker_drop render test was occasionally
flaky.

Reproduce it by running this command:

    while cargo test --all-features ticker_drop; do :; done

It will eventually fail with something like this:

```
running 1 test
test ticker_drop ... FAILED

failures:

---- ticker_drop stdout ----
thread 'ticker_drop' panicked at 'assertion failed: `(left == right)`
  left: `"⠁ doing stuff 0\n  doing stuff 1\n  doing stuff 2\n  doing stuff 3\n  doing stuff 4"`,
 right: `"  doing stuff 0\n  doing stuff 1\n  doing stuff 2\n  doing stuff 3\n  doing stuff 4"`', tests/render.rs:347:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Somehow the spinner is not correctly getting finished. Clearly there is
a subtle race condition somewhere but I haven't been able to track it
down.