### PR TITLE
Correct mis-naming of variables in wrap_async_read

### DIFF
--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -498,10 +498,10 @@ impl ProgressBar {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn wrap_async_read<W: tokio::io::AsyncRead + Unpin>(&self, write: W) -> ProgressBarIter<W> {
+    pub fn wrap_async_read<R: tokio::io::AsyncRead + Unpin>(&self, read: R) -> ProgressBarIter<R> {
         ProgressBarIter {
             progress: self.clone(),
-            it: write,
+            it: read,
         }
     }
 


### PR DESCRIPTION
This was slightly confusing when I saw it in IDE.