### PR TITLE
Remove `write_all` from `ProgressBarIter`'s `Write` trait

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -287,12 +287,6 @@ impl<W: io::Write> io::Write for ProgressBarIter<W> {
         self.it.flush()
     }
 
-    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
-        self.it.write_all(buf).map(|()| {
-            self.progress.inc(buf.len() as u64);
-        })
-    }
-
     // write_fmt can not be captured with reasonable effort.
     // as it uses write_all internally by default that should not be a problem.
     // fn write_fmt(&mut self, fmt: fmt::Arguments) -> io::Result<()>;


### PR DESCRIPTION
By implementing `write_all` we lose granularity of progress updates
that are captured from `write`.  Therefore, remove this function.  This also brings the `ProgressBarIter`'s `Write` trait into line with the `Read` trait since that doesn't provide an implementation of `read_all`.