### PR TITLE
Bump version to 0.17.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "indicatif"
 description = "A progress bar and cli reporting library for Rust"
-version = "0.17.0"
+version = "0.17.1"
 keywords = ["cli", "progress", "pb", "colors", "progressbar"]
 categories = ["command-line-interface"]
 license = "MIT"


### PR DESCRIPTION
I think it's time -- we've cleared most of the regressions, though we're still tracking the estimator stuff in #394.