### PR TITLE
Bump MSRV to 1.56

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,17 +10,17 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        rust: [stable, beta, 1.53]
+        rust: [stable, beta, 1.56]
         features: [--all-features, ""]
         exclude:
           - os: ubuntu-latest
             rust: beta
             features: ""
           - os: ubuntu-latest
-            rust: 1.53
+            rust: 1.56
             features: --all-features
           - os: ubuntu-latest
-            rust: 1.53
+            rust: 1.56
             features: ""
           - os: macos-latest
             rust: stable
@@ -32,10 +32,10 @@ jobs:
             rust: beta
             features: ""
           - os: macos-latest
-            rust: 1.53
+            rust: 1.56
             features: --all-features
           - os: macos-latest
-            rust: 1.53
+            rust: 1.56
             features: ""
           - os: windows-latest
             rust: stable
@@ -47,14 +47,14 @@ jobs:
             rust: beta
             features: ""
           - os: windows-latest
-            rust: 1.53
+            rust: 1.56
             features: --all-features
           - os: windows-latest
-            rust: 1.53
+            rust: 1.56
             features: ""
         include:
           - os: ubuntu-latest
-            rust: 1.53
+            rust: 1.56
             features: --features improved_unicode
 
     runs-on: ${{ matrix.os }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ documentation = "https://docs.rs/indicatif"
 readme = "README.md"
 edition = "2018"
 exclude = ["screenshots/*"]
+rust-version = "1.56"
 
 [dependencies]
 console = { version = "0.15", default-features = false, features = ["ansi-parsing"] }


### PR DESCRIPTION
The latest version of once_cell now requires 1.56. This is old enough at this point that we should just bump our MSRV, too.