### PR TITLE
Remove `"fs"` feature in tokio dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ vt100 = { version = "0.15.1", optional = true }
 once_cell = "1"
 rand = "0.8"
 structopt = "0.3"
-tokio = { version = "1", features = ["time", "rt"] }
+tokio = { version = "1", features = ["fs", "time", "rt"] }
 
 [features]
 default = ["unicode-width", "console/unicode-width"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ console = { version = "0.15", default-features = false, features = ["ansi-parsin
 number_prefix = "0.4"
 portable-atomic = "0.3.15"
 rayon = { version = "1.1", optional = true }
-tokio = { version = "1", optional = true, features = ["fs", "io-util"] }
+tokio = { version = "1", optional = true, features = ["io-util"] }
 unicode-segmentation = { version = "1", optional = true }
 unicode-width = { version = "0.1", optional = true }
 vt100 = { version = "0.15.1", optional = true }


### PR DESCRIPTION
Heya, this allows `indicatif` to compile to WASM. I've checked and `tokio::fs` is not used in the project.