### PR TITLE
docs(lib): update style reference for alignment characters

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@
 //! where the `options` part is optional.  If provided the format is this:
 //!
 //! ```text
-//! [<^>]           for an optional alignment specification
+//! <^>             for an optional alignment specification (Left, Center and Right respectively)
 //! WIDTH           an optional width as positive integer
 //! !               an optional exclamation mark to enable truncation
 //! .STYLE          an optional dot separated style string

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@
 //! where the `options` part is optional.  If provided the format is this:
 //!
 //! ```text
-//! <^>             for an optional alignment specification (Left, Center and Right respectively)
+//! <^>             for an optional alignment specification (left, center and right respectively)
 //! WIDTH           an optional width as positive integer
 //! !               an optional exclamation mark to enable truncation
 //! .STYLE          an optional dot separated style string


### PR DESCRIPTION
This PR updates the Templates sections's style characters for Alignment, to have a consistent style guide (removing characters that are not actually part of the style) and adding a clarification on what each character does 

fixes #509