### PR TITLE
Use `instant::Instant` when compiling to WASM.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ rand = "0.8"
 structopt = "0.3"
 tokio = { version = "1", features = ["fs", "time", "rt"] }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+instant = "0.1"
+
 [features]
 default = ["unicode-width", "console/unicode-width"]
 improved_unicode = ["unicode-segmentation", "unicode-width", "console/unicode-width"]

--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -1,9 +1,13 @@
 use std::io;
 use std::sync::{Arc, RwLock, RwLockWriteGuard};
 use std::thread::panicking;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Instant;
 
 use console::Term;
+#[cfg(target_arch = "wasm32")]
+use instant::Instant;
 
 use crate::multi::{MultiProgressAlignment, MultiState};
 use crate::TermLike;

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -2,10 +2,13 @@ use std::fmt::{Debug, Formatter};
 use std::io;
 use std::sync::{Arc, RwLock};
 use std::thread::panicking;
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
 
 use crate::draw_target::{DrawState, DrawStateWrapper, LineAdjust, ProgressDrawTarget};
 use crate::progress_bar::ProgressBar;
+#[cfg(target_arch = "wasm32")]
+use instant::Instant;
 
 /// Manages multiple progress bars from different threads
 #[derive(Debug, Clone)]

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -2,9 +2,13 @@
 use portable_atomic::{AtomicBool, Ordering};
 use std::borrow::Cow;
 use std::sync::{Arc, Condvar, Mutex, MutexGuard, Weak};
-use std::time::{Duration, Instant};
+use std::time::Duration;
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Instant;
 use std::{fmt, io, thread};
 
+#[cfg(target_arch = "wasm32")]
+use instant::Instant;
 #[cfg(test)]
 use once_cell::sync::Lazy;
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,8 +1,12 @@
 use std::borrow::Cow;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Instant;
 use std::{fmt, io};
 
+#[cfg(target_arch = "wasm32")]
+use instant::Instant;
 use portable_atomic::{AtomicU64, AtomicU8, Ordering};
 
 use crate::draw_target::ProgressDrawTarget;

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,9 +1,12 @@
 use std::collections::HashMap;
 use std::fmt::{self, Write};
 use std::mem;
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
 
 use console::{measure_text_width, Style};
+#[cfg(target_arch = "wasm32")]
+use instant::Instant;
 #[cfg(feature = "unicode-segmentation")]
 use unicode_segmentation::UnicodeSegmentation;
 


### PR DESCRIPTION
Addresses #513.