### PR TITLE
Color % symbol in template

### DIFF
--- a/src/style.rs
+++ b/src/style.rs
@@ -282,6 +282,9 @@ impl ProgressStyle {
                             "percent" => buf
                                 .write_fmt(format_args!("{:.*}", 0, state.fraction() * 100f32))
                                 .unwrap(),
+                            "percent%" => buf
+                                .write_fmt(format_args!("{:.*}%", 0, state.fraction() * 100f32))
+                                .unwrap(),
                             "bytes" => buf.write_fmt(format_args!("{}", HumanBytes(pos))).unwrap(),
                             "total_bytes" => {
                                 buf.write_fmt(format_args!("{}", HumanBytes(len))).unwrap();


### PR DESCRIPTION
Add percent% to convenience set % symbol color

Before:
```
{percent:>3.blue}" + &style("%").blue().to_string()
```

After:
```
 {percent%:>3.blue}"
```
