### PR TITLE
Add option for JSON escaping for placeholder values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ tokio = { version = "1", optional = true, features = ["io-util"] }
 unicode-segmentation = { version = "1", optional = true }
 unicode-width = { version = "0.1", optional = true }
 vt100 = { version = "0.15.1", optional = true }
+json = { version = "0.12.4" }
 
 [dev-dependencies]
 clap = { version = "3", features = ["color", "derive"] }


### PR DESCRIPTION
Refs #525 (I went ahead and wrote some code...).

This PR

* adds an option (`json_strings`) to have `ProgressStyle` escape all of the dynamic strings it outputs as JSON strings
* a convenience helper `with_json_keys` to create a `ProgressStyle` with a template that outputs a well-formed JSON object

IOW, a `ProgressStyle` with `json_strings(true)` and a template
```
{{"pos": {pos}, "len": {len}, "prefix": {prefix}, "msg": {msg}}}
```
(this is what `ProgressStyle::with_json_keys(&["pos", "len", "prefix", "msg"])` would internally generate) will result in progress lines like 
```
{"pos": "1", "len": "10", "prefix": "hello", "msg": "something"}
```
which can then be sent to a `TermLike` target (#354, #526) to implement #525 :)

---

If you like, I can put this behind a `feature` gate to avoid the `json` dependency – but what should `indicatif` do when trying to do JSON output when it's not compiled in? I'm pretty sure we wouldn't want it to just output non-escaped JSON...