### PR TITLE
Implement Clone for ProgressDrawTarget

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = "1.58"
 
 [dependencies]
 console = { version = "0.15", default-features = false, features = ["ansi-parsing"] }
+dyn-clone = "1.0.11"
 number_prefix = "0.4"
 portable-atomic = "1.0.0"
 rayon = { version = "1.1", optional = true }

--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -18,7 +18,7 @@ use crate::TermLike;
 /// The draw target is a stateful wrapper over a drawing destination and
 /// internally optimizes how often the state is painted to the output
 /// device.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ProgressDrawTarget {
     kind: TargetKind,
 }
@@ -205,7 +205,7 @@ impl ProgressDrawTarget {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum TargetKind {
     Term {
         term: Term,
@@ -373,7 +373,7 @@ impl Drop for DrawStateWrapper<'_> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct RateLimiter {
     interval: u16, // in milliseconds
     capacity: u8,

--- a/src/term_like.rs
+++ b/src/term_like.rs
@@ -2,13 +2,14 @@ use std::fmt::Debug;
 use std::io;
 
 use console::Term;
+use dyn_clone::DynClone;
 
 /// A trait for minimal terminal-like behavior.
 ///
 /// Anything that implements this trait can be used a draw target via [`ProgressDrawTarget::term_like`].
 ///
 /// [`ProgressDrawTarget::term_like`]: crate::ProgressDrawTarget::term_like
-pub trait TermLike: Debug + Send + Sync {
+pub trait TermLike: Debug + Send + Sync + DynClone {
     /// Return the terminal width
     fn width(&self) -> u16;
 
@@ -30,6 +31,8 @@ pub trait TermLike: Debug + Send + Sync {
 
     fn flush(&self) -> io::Result<()>;
 }
+
+dyn_clone::clone_trait_object!(TermLike);
 
 impl TermLike for Term {
     fn width(&self) -> u16 {


### PR DESCRIPTION
Uses [dyn-clone](https://github.com/dtolnay/dyn-clone) to make `ProgressDrawTarget` and `TermLike` cloneable.