### PR TITLE
Handle terminal line wrap to avoid new line

### DIFF
--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -494,7 +494,13 @@ impl DrawState {
         };
 
         let len = self.lines.len();
+        let mut real_len = 0;
         for (idx, line) in self.lines.iter().enumerate() {
+            // Calculate real length based on terminal width
+            // This take in account linewrap from terminal
+            real_len +=
+                (console::measure_text_width(line) as f64 / term.width() as f64).ceil() as usize;
+
             if idx + 1 != len {
                 term.write_line(line)?;
             } else {
@@ -509,7 +515,7 @@ impl DrawState {
         }
 
         term.flush()?;
-        *last_line_count = self.lines.len() - self.orphan_lines_count + shift;
+        *last_line_count = real_len - self.orphan_lines_count + shift;
         Ok(())
     }
 

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -916,3 +916,131 @@ fn multi_progress_bottom_alignment() {
     in_mem.write_line("anchor").unwrap();
     assert_eq!(in_mem.contents(), "\n\nanchor");
 }
+
+#[test]
+fn progress_bar_terminal_wrap() {
+    use std::cmp::min;
+    let in_mem = InMemoryTerm::new(10, 20);
+
+    let mut downloaded = 0;
+    let total_size = 231231231;
+
+    let pb = ProgressBar::with_draw_target(
+        None,
+        ProgressDrawTarget::term_like(Box::new(in_mem.clone())),
+    );
+    pb.set_style(ProgressStyle::default_bar()
+        .template("{msg:>12.cyan.bold} {spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {bytes}/{total_bytes}").unwrap()
+        .progress_chars("#>-"));
+
+    pb.set_message("Downloading");
+    assert_eq!(
+        in_mem.contents(),
+        r#" Downloading ⠁ [00:0
+0:00] [-------------
+--------------------
+-------] 0B/0B"#
+    );
+
+    let new = min(downloaded + 223211, total_size);
+    downloaded = new;
+    pb.set_position(new);
+    assert_eq!(
+        in_mem.contents(),
+        r#" Downloading ⠁ [00:0
+0:00] [-------------
+--------------------
+-------] 217.98 KiB/
+217.98 KiB"#
+    );
+
+    let new = min(downloaded + 223211, total_size);
+    pb.set_position(new);
+    assert_eq!(
+        in_mem.contents(),
+        r#" Downloading ⠉ [00:0
+0:00] [-------------
+--------------------
+-------] 435.96 KiB/
+435.96 KiB"#
+    );
+
+    pb.set_style(
+        ProgressStyle::default_bar()
+            .template("{msg:>12.green.bold} downloading {total_bytes:.green} in {elapsed:.green}")
+            .unwrap(),
+    );
+    pb.finish_with_message("Finished");
+    assert_eq!(
+        in_mem.contents(),
+        r#"    Finished downloa
+ding 435.96 KiB in 0
+s"#
+    );
+
+    println!("{:?}", in_mem.contents())
+}
+
+#[test]
+fn multi_progress_println_terminal_wrap() {
+    let in_mem = InMemoryTerm::new(10, 48);
+    let mp =
+        MultiProgress::with_draw_target(ProgressDrawTarget::term_like(Box::new(in_mem.clone())));
+
+    let pb1 = mp.add(ProgressBar::new(10));
+    let pb2 = mp.add(ProgressBar::new(5));
+    let pb3 = mp.add(ProgressBar::new(100));
+
+    assert_eq!(in_mem.contents(), "");
+
+    pb1.inc(2);
+    mp.println("message printed that is longer than terminal width :)")
+        .unwrap();
+    assert_eq!(
+        in_mem.contents(),
+        r#"message printed that is longer than terminal wid
+th :)
+████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 2/10"#
+    );
+
+    mp.println("another great message!").unwrap();
+    assert_eq!(
+        in_mem.contents(),
+        r#"message printed that is longer than terminal wid
+th :)
+another great message!
+████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 2/10"#
+    );
+
+    pb2.inc(1);
+    pb3.tick();
+    mp.println("one last message but this one is also longer than terminal width")
+        .unwrap();
+
+    assert_eq!(
+        in_mem.contents(),
+        r#"message printed that is longer than terminal wid
+th :)
+another great message!
+one last message but this one is also longer tha
+n terminal width
+████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 2/10
+████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 1/5
+░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 0/100"#
+            .trim()
+    );
+
+    drop(pb1);
+    drop(pb2);
+    drop(pb3);
+
+    assert_eq!(
+        in_mem.contents(),
+        r#"message printed that is longer than terminal wid
+th :)
+another great message!
+one last message but this one is also longer tha
+n terminal width"#
+            .trim()
+    );
+}


### PR DESCRIPTION
Terminal usually wrap line in case it can't fit the current terminal width. 
This behavior is not taken in account by indicatif and create some visual artifacts.

The issue was reported as #144 (closed with a workaround) and #520.

Please find below a demo **without** the patch:
![WindowsTerminal_wwpvPvmRKY](https://user-images.githubusercontent.com/64585623/232417242-2ef21734-583d-4947-8827-1a6cf2ba7544.gif)

Demo **with** the patch:
![WindowsTerminal_Q7z1mdXh3O](https://user-images.githubusercontent.com/64585623/232417323-40dfc5bb-8a66-424f-8143-e918d362b6e4.gif)

Using #144 example:
![WindowsTerminal_HVhbcstdMB](https://user-images.githubusercontent.com/64585623/232417802-651d9b91-0b76-4fbd-9aa5-f05683ae2751.gif)

