### PR TITLE
resetting the elapsed time also resets ETA

### DIFF
--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -307,7 +307,7 @@ impl ProgressBar {
         self.state().reset(Instant::now(), Reset::Eta);
     }
 
-    /// Resets elapsed time
+    /// Resets elapsed time and the ETA calculation
     pub fn reset_elapsed(&self) {
         self.state().reset(Instant::now(), Reset::Elapsed);
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -69,9 +69,9 @@ impl BarState {
     }
 
     pub(crate) fn reset(&mut self, now: Instant, mode: Reset) {
-        if let Reset::Eta | Reset::All = mode {
-            self.state.est.reset(now);
-        }
+        // Always reset the estimator; this is the only reset that will occur if mode is
+        // `Reset::Eta`.
+        self.state.est.reset(now);
 
         if let Reset::Elapsed | Reset::All = mode {
             self.state.started = now;


### PR DESCRIPTION
It makes sense to reset the ETA without resetting the time elapsed back to zero, but when setting the time elapsed back to zero, the ETA should also be reset as this should make the progress bar behave as if it had just been activated (in a partially complete state).

Fixes https://github.com/console-rs/indicatif/issues/536.