### PR TITLE
Handle newline in msg and empty msg

### DIFF
--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -496,11 +496,15 @@ impl DrawState {
         let len = self.lines.len();
         let mut real_len = 0;
         for (idx, line) in self.lines.iter().enumerate() {
-            // Calculate real length based on terminal width
-            // This take in account linewrap from terminal
-            real_len +=
-                (console::measure_text_width(line) as f64 / term.width() as f64).ceil() as usize;
-
+            if line.is_empty() {
+                // Empty line are new line
+                real_len += 1;
+            } else {
+                // Calculate real length based on terminal width
+                // This take in account linewrap from terminal
+                real_len += (console::measure_text_width(line) as f64 / term.width() as f64).ceil()
+                    as usize;
+            }
             if idx + 1 != len {
                 term.write_line(line)?;
             } else {

--- a/src/state.rs
+++ b/src/state.rs
@@ -143,7 +143,13 @@ impl BarState {
         };
 
         let mut draw_state = drawable.state();
-        draw_state.lines.extend(msg.lines().map(Into::into));
+        let lines: Vec<String> = msg.lines().map(Into::into).collect();
+        // Empty msg should trigger newline as we are in println
+        if lines.is_empty() {
+            draw_state.lines.push(String::new());
+        } else {
+            draw_state.lines.extend(lines);
+        }
         draw_state.orphan_lines_count = draw_state.lines.len();
         if !matches!(self.state.status, Status::DoneHidden) {
             self.style

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -1044,3 +1044,42 @@ n terminal width"#
             .trim()
     );
 }
+
+#[test]
+fn basic_progress_bar_newline() {
+    let in_mem = InMemoryTerm::new(10, 80);
+    let pb = ProgressBar::with_draw_target(
+        Some(10),
+        ProgressDrawTarget::term_like(Box::new(in_mem.clone())),
+    );
+
+    assert_eq!(in_mem.contents(), String::new());
+
+    pb.println("\nhello");
+    pb.tick();
+    assert_eq!(
+        in_mem.contents(),
+        r#"
+hello
+░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 0/10"#
+    );
+
+    pb.inc(1);
+    pb.println("");
+    assert_eq!(
+        in_mem.contents(),
+        r#"
+hello
+
+███████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 1/10"#
+    );
+
+    pb.finish();
+    assert_eq!(
+        in_mem.contents(),
+        "
+hello
+
+██████████████████████████████████████████████████████████████████████████ 10/10"
+    );
+}


### PR DESCRIPTION
Using `println()` with a new line at the beginning of the message trigger some artifacts, see below:

`newline_artifact.rs`
```
use indicatif::ProgressBar;

fn main() {
    let pb = ProgressBar::new(1024);
    pb.inc(1);
    pb.println("\nShould be a new line before this message and no duplicate progress bar");
    pb.finish_with_message("done");
}
```
Output on `main`:
![image](https://github.com/console-rs/indicatif/assets/64585623/f8357aa0-de1f-4e29-b431-df44aa3a431e)
Output with this patch:
![image](https://github.com/console-rs/indicatif/assets/64585623/f77644dd-983d-4540-b6a4-94ba7b77b88d)

-----

Using `println()` with an empty string does not trigger new line:
`empty_msg.rs`
```
use indicatif::ProgressBar;

fn main() {
    let pb = ProgressBar::new(1024);
    pb.inc(1);
    pb.println("");
    pb.println("There should an empty line before this message");
    pb.finish_with_message("done");
}
```
Output on `main`:
![image](https://github.com/console-rs/indicatif/assets/64585623/5dc11f7e-4961-43d9-8026-cc3da5768da0)

Output with this patch:
![image](https://github.com/console-rs/indicatif/assets/64585623/d9e0e571-27ac-4330-8438-6b491ed7f9fd)

New test in `render.rs` showcase both issue