### PR TITLE
Prepare 0.17.4 release

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,7 +70,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: "1.58"
+          toolchain: "1.62.1"
           override: true
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,9 +21,6 @@ jobs:
             rust: beta
             features: --all-features
           - os: ubuntu-latest
-            rust: 1.58
-            features: --features improved_unicode
-          - os: ubuntu-latest
             rust: stable
             features: --all-features
             target: --target armv5te-unknown-linux-gnueabi
@@ -65,6 +62,20 @@ jobs:
           use-cross: ${{ matrix.use-cross }}
           command: test
           args: --workspace ${{ matrix.features }} ${{ matrix.target }}
+
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: "1.58"
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --lib --all-features
 
   lint:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ unicode-width = { version = "0.1", optional = true }
 vt100 = { version = "0.15.1", optional = true }
 
 [dev-dependencies]
-clap = { version = "3", features = ["color", "derive"] }
+clap = { version = "4", features = ["color", "derive"] }
 once_cell = "1"
 rand = "0.8"
 tokio = { version = "1", features = ["fs", "time", "rt"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/indicatif"
 readme = "README.md"
 edition = "2018"
 exclude = ["screenshots/*"]
-rust-version = "1.58"
+rust-version = "1.62.1"
 
 [dependencies]
 console = { version = "0.15", default-features = false, features = ["ansi-parsing"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "indicatif"
 description = "A progress bar and cli reporting library for Rust"
-version = "0.17.3"
+version = "0.17.4"
 keywords = ["cli", "progress", "pb", "colors", "progressbar"]
 categories = ["command-line-interface"]
 license = "MIT"


### PR DESCRIPTION
Fixes #541.

Changelog:

* Handle newline in msg and empty msg (#540, thanks to RDruon)
* Handle terminal line wrap to avoid new line (#533, thanks to RDruon)
* Resetting the elapsed time also resets ETA (#538, thanks to afontenot)
* Mention the prefix and message placeholders in the `with_` docs (#529, thanks to lnicola)
* Allow rate-limiting `TermLike` targets (#526, thanks to akx)
* Fix docs for `ProgressDrawTarget` (#523, thanks to tillarnold)
* Change "OS X" to "macOS" (#519, thanks to atouchet)
* Fix `MultiProgress` alignment handling and migrate from structopt => clap (#516)
* Don't deadlock when double-adding ProgressBar (#515)
* Use `instant::Instant` when compiling to WASM (#514, thanks to azriel91)
* Update portable-atomic requirement from 0.3.15 to 1.0.0 (#512)
* `inc()` after work in examples (#522, thanks to tatref)