### PR TITLE
Fix subtract with overflow when measuring terminal line length

### DIFF
--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -502,8 +502,14 @@ impl DrawState {
             } else {
                 // Calculate real length based on terminal width
                 // This take in account linewrap from terminal
-                real_len += (console::measure_text_width(line) as f64 / term.width() as f64).ceil()
-                    as usize;
+                let terminal_len = (console::measure_text_width(line) as f64 / term.width() as f64)
+                    .ceil() as usize;
+
+                // If the line is effectively empty (for example when it consists
+                // solely of ANSI color code sequences, count it the same as a
+                // new line. If the line is measured to be len = 0, we will
+                // subtract with overflow later.
+                real_len += usize::max(terminal_len, 1);
             }
             if idx + 1 != len {
                 term.write_line(line)?;

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -982,6 +982,25 @@ s"#
 }
 
 #[test]
+fn spinner_terminal_cleared_log_line_with_ansi_codes() {
+    let in_mem = InMemoryTerm::new(10, 100);
+
+    let pb = ProgressBar::with_draw_target(
+        Some(10),
+        ProgressDrawTarget::term_like(Box::new(in_mem.clone())),
+    );
+    pb.set_style(ProgressStyle::default_spinner());
+    assert_eq!(in_mem.contents(), String::new());
+
+    pb.finish_and_clear();
+    // Visually empty, but consists of an ANSII code
+    pb.println("\u{1b}[1m");
+
+    pb.println("text\u{1b}[0m");
+    assert_eq!(in_mem.contents(), "\ntext");
+}
+
+#[test]
 fn multi_progress_println_terminal_wrap() {
     let in_mem = InMemoryTerm::new(10, 48);
     let mp =


### PR DESCRIPTION
If console::measure_text_width returns 0, the line is effectively empty, although line.is_empty() may still be false. This can for example happen when there is a line which just consists of ANSI color escape sequences.

I hope I didn't undo the work done in #533.

An alternative would be to do:

```
// make sure we never subtract with overflow
let real_len = max(real_len, self.orphan_lines_count + shift);

*last_line_count = real_len - self.orphan_lines_count + shift;
```

closes #546