### PR TITLE
Add builder-like `with_finish` method to `ProgressBarIter`.

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -13,6 +13,7 @@ use tokio::io::{ReadBuf, SeekFrom};
 
 use crate::progress_bar::ProgressBar;
 use crate::style::ProgressStyle;
+use crate::state::ProgressFinish;
 
 /// Wraps an iterator to display its progress.
 pub trait ProgressIterator
@@ -101,6 +102,14 @@ impl<T> ProgressBarIter<T> {
     /// See [ProgressBar::with_elapsed].
     pub fn with_elapsed(mut self, elapsed: Duration) -> Self {
         self.progress = self.progress.with_elapsed(elapsed);
+        self
+    }
+
+    /// Builder-like function for setting underlying progress bar's finish behavior.
+    ///
+    /// See [ProgressBar::with_finish].
+    pub fn with_finish(mut self, finish: ProgressFinish) -> Self {
+        self.progress = self.progress.with_finish(finish);
         self
     }
 }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -12,8 +12,8 @@ use std::time::Duration;
 use tokio::io::{ReadBuf, SeekFrom};
 
 use crate::progress_bar::ProgressBar;
-use crate::style::ProgressStyle;
 use crate::state::ProgressFinish;
+use crate::style::ProgressStyle;
 
 /// Wraps an iterator to display its progress.
 pub trait ProgressIterator


### PR DESCRIPTION
This lets you more concisely set the finish behavior of the progress bar when using `ProgressBarIter`.

For example, to show a progress bar and keep it displayed when it finishes, you can do

```
v.iter().progress().with_finish(ProgressFinish::AndLeave)
```

instead of

```
v.iter()
        .progress_with(ProgressBar::new(v.len() as u64).with_finish(ProgressFinish::AndLeave));
```

Closes #545
