### PR TITLE
tests: suppress clippy redundant clone check in test code

### DIFF
--- a/tests/multi-autodrop.rs
+++ b/tests/multi-autodrop.rs
@@ -12,6 +12,7 @@ fn main() {
     };
 
     {
+        #[allow(clippy::redundant_clone)]
         let pb2 = pb.clone();
         for _ in 0..10 {
             pb2.inc(1);


### PR DESCRIPTION
Seems to be a new or at least tweaked clippy check. It is now causing lint failure.