### PR TITLE
Add `decimal_bytes_per_sec` state formatter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,9 +175,17 @@
 //! * `len`: renders the amount of work to be done as an integer
 //! * `human_len`: renders the total length of the bar as an integer, with commas as the thousands
 //! separator.
-//! * `bytes`: renders the current position of the bar as bytes.
 //! * `percent`: renders the current position of the bar as a percentage of the total length.
+//! * `bytes`: renders the current position of the bar as bytes.
 //! * `total_bytes`: renders the total length of the bar as bytes.
+//! * `decimal_bytes`: renders the current position of the bar as bytes using
+//!   SI units, i.e. `MB`, `kB`, etc.
+//! * `decimal_total_bytes`: renders the total length of the bar as bytes using
+//!   SI units, i.e. `MB`, `kB`, etc.
+//! * `binary_bytes`: renders the current position of the bar as bytes using
+//!   power-of-two units, i.e. `MiB`, `KiB`, etc.
+//! * `binary_total_bytes`: renders the total length of the bar as bytes using
+//!   power-of-two units, i.e. `MiB`, `KiB`, etc.
 //! * `elapsed_precise`: renders the elapsed time as `HH:MM:SS`.
 //! * `elapsed`: renders the elapsed time as `42s`, `1m` etc.
 //! * `per_sec`: renders the speed in steps per second.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,6 +182,8 @@
 //! * `elapsed`: renders the elapsed time as `42s`, `1m` etc.
 //! * `per_sec`: renders the speed in steps per second.
 //! * `bytes_per_sec`: renders the speed in bytes per second.
+//! * `decimal_bytes_per_sec`: renders the speed in bytes per second using
+//!   SI units, i.e. `MB`, `kB`, etc.
 //! * `binary_bytes_per_sec`: renders the speed in bytes per second using
 //!   power-of-two units, i.e. `MiB`, `KiB`, etc.
 //! * `eta_precise`: the remaining time (like `elapsed_precise`).

--- a/src/style.rs
+++ b/src/style.rs
@@ -310,6 +310,12 @@ impl ProgressStyle {
                             "bytes_per_sec" => buf
                                 .write_fmt(format_args!("{}/s", HumanBytes(state.per_sec() as u64)))
                                 .unwrap(),
+                            "decimal_bytes_per_sec" => buf
+                                .write_fmt(format_args!(
+                                    "{}/s",
+                                    DecimalBytes(state.per_sec() as u64)
+                                ))
+                                .unwrap(),
                             "binary_bytes_per_sec" => buf
                                 .write_fmt(format_args!(
                                     "{}/s",


### PR DESCRIPTION
This PR simply adds a `decimal_bytes_per_sec` state formatter.  

Since `bytes_per_sec` and `binary_bytes_per_sec` are both formatted using power-of-two units, it felt like a `decimal_bytes_per_sec` formatter (for using SI units) was missing.  

This follows in the same spirit as the `bytes` and `total_bytes` formatters, which both have `binary` and `decimal` variants.

This PR also updates the docs to mention these `binary` and `decimal` variants being available, which were missing even for `bytes` and `total_bytes`.  