### PR TITLE
feat: add futures::Stream support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = "1.62.1"
 
 [dependencies]
 console = { version = "0.15", default-features = false, features = ["ansi-parsing"] }
+futures-core = { version = "0.3", default-features = false, optional = true }
 number_prefix = "0.4"
 portable-atomic = "1.0.0"
 rayon = { version = "1.1", optional = true }
@@ -27,6 +28,7 @@ clap = { version = "4", features = ["color", "derive"] }
 once_cell = "1"
 rand = "0.8"
 tokio = { version = "1", features = ["fs", "time", "rt"] }
+futures = "0.3"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 instant = "0.1"
@@ -35,6 +37,7 @@ instant = "0.1"
 default = ["unicode-width", "console/unicode-width"]
 improved_unicode = ["unicode-segmentation", "unicode-width", "console/unicode-width"]
 in_memory = ["vt100"]
+futures = ["dep:futures-core"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ clap = { version = "4", features = ["color", "derive"] }
 once_cell = "1"
 rand = "0.8"
 tokio = { version = "1", features = ["fs", "time", "rt"] }
-futures = "0.3"
+futures = "0.3" # so the doctest for wrap_stream is nice
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 instant = "0.1"

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -526,10 +526,7 @@ impl ProgressBar {
     /// ```
     #[cfg(feature = "futures")]
     #[cfg_attr(docsrs, doc(cfg(feature = "futures")))]
-    pub fn wrap_stream(
-        &self,
-        stream: impl futures_core::Stream,
-    ) -> ProgressBarIter<impl futures_core::Stream> {
+    pub fn wrap_stream<S: futures_core::Stream>(&self, stream: S) -> ProgressBarIter<S> {
         ProgressBarIter {
             progress: self.clone(),
             it: stream,

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -511,6 +511,30 @@ impl ProgressBar {
         }
     }
 
+    /// Wraps a [`futures::Stream`](https://docs.rs/futures/0.3/futures/stream/trait.StreamExt.html) with the progress bar
+    ///
+    /// ```
+    /// # use indicatif::ProgressBar;
+    /// use futures::stream::{self, StreamExt};
+    /// # async fn test() {
+    /// let pb = ProgressBar::new(10);
+    ///
+    /// let stream = pb.wrap_stream(stream::iter(1..=10));
+    /// assert_eq!(
+    ///     stream.count().await,
+    ///     10,
+    /// );
+    /// # }
+    /// ```
+    #[cfg(feature = "futures")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "futures")))]
+    pub fn wrap_stream<S: futures_core::Stream>(&self, stream: S) -> ProgressBarIter<S> {
+        ProgressBarIter {
+            progress: self.clone(),
+            it: stream,
+        }
+    }
+
     /// Returns the current position
     pub fn position(&self) -> u64 {
         self.state().state.pos()

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -528,7 +528,10 @@ impl ProgressBar {
     /// ```
     #[cfg(feature = "futures")]
     #[cfg_attr(docsrs, doc(cfg(feature = "futures")))]
-    pub fn wrap_stream<S: futures_core::Stream>(&self, stream: S) -> ProgressBarIter<S> {
+    pub fn wrap_stream(
+        &self,
+        stream: impl futures_core::Stream,
+    ) -> ProgressBarIter<impl futures_core::Stream> {
         ProgressBarIter {
             progress: self.clone(),
             it: stream,

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -515,16 +515,14 @@ impl ProgressBar {
     ///
     /// ```
     /// # use indicatif::ProgressBar;
+    /// # futures::executor::block_on(async {
     /// use futures::stream::{self, StreamExt};
-    /// # async fn test() {
     /// let pb = ProgressBar::new(10);
+    /// let mut stream = pb.wrap_stream(stream::iter('a'..='z'));
     ///
-    /// let stream = pb.wrap_stream(stream::iter(1..=10));
-    /// assert_eq!(
-    ///     stream.count().await,
-    ///     10,
-    /// );
-    /// # }
+    /// assert_eq!(stream.next().await, Some('a'));
+    /// assert_eq!(stream.count().await, 25);
+    /// # }); // block_on
     /// ```
     #[cfg(feature = "futures")]
     #[cfg_attr(docsrs, doc(cfg(feature = "futures")))]


### PR DESCRIPTION
I've mostly just copied the existing patterns for iterator and asyncread