### PR TITLE
fix overflow crash when displaying ETA

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -77,7 +77,7 @@ impl fmt::Display for HumanDuration {
         for (i, &(cur, _, _)) in UNITS.iter().enumerate() {
             idx = i;
             match UNITS.get(i + 1) {
-                Some(&next) if self.0 + next.0 / 2 >= cur + cur / 2 => break,
+                Some(&next) if self.0.saturating_add(next.0 / 2) >= cur + cur / 2 => break,
                 _ => continue,
             }
         }


### PR DESCRIPTION
Possible fix for https://github.com/console-rs/indicatif/issues/554, but I wasn't thorough checking for other possible sources of overflow (in particular in the ETA calculation itself, though from a glance it seems OK)