### PR TITLE
fix `ProgressState::duration()` overflow

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -293,7 +293,7 @@ impl ProgressState {
         if self.len.is_none() || self.is_finished() {
             return Duration::new(0, 0);
         }
-        self.started.elapsed() + self.eta()
+        self.started.elapsed().saturating_add(self.eta())
     }
 
     /// The number of steps per second


### PR DESCRIPTION
In scenarios where the `ProgressState::eta()` returns very high/maxed `Duration`, calling `ProgressState::duration()` can panic as `elapsed + eta` overflows.

This PR avoids that panic. In this scenario `ProgressState::duration()` will return `Duration::MAX`.

Fixes #561 