### PR TITLE
Add missing space before unit

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -109,7 +109,7 @@ const UNITS: &[(Duration, &str, &str)] = &[
 impl fmt::Display for HumanBytes {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match NumberPrefix::binary(self.0 as f64) {
-            NumberPrefix::Standalone(number) => write!(f, "{number:.0}B"),
+            NumberPrefix::Standalone(number) => write!(f, "{number:.0} B"),
             NumberPrefix::Prefixed(prefix, number) => write!(f, "{number:.2} {prefix}B"),
         }
     }
@@ -118,7 +118,7 @@ impl fmt::Display for HumanBytes {
 impl fmt::Display for DecimalBytes {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match NumberPrefix::decimal(self.0 as f64) {
-            NumberPrefix::Standalone(number) => write!(f, "{number:.0}B"),
+            NumberPrefix::Standalone(number) => write!(f, "{number:.0} B"),
             NumberPrefix::Prefixed(prefix, number) => write!(f, "{number:.2} {prefix}B"),
         }
     }
@@ -127,7 +127,7 @@ impl fmt::Display for DecimalBytes {
 impl fmt::Display for BinaryBytes {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match NumberPrefix::binary(self.0 as f64) {
-            NumberPrefix::Standalone(number) => write!(f, "{number:.0}B"),
+            NumberPrefix::Standalone(number) => write!(f, "{number:.0} B"),
             NumberPrefix::Prefixed(prefix, number) => write!(f, "{number:.2} {prefix}B"),
         }
     }

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -939,7 +939,7 @@ fn progress_bar_terminal_wrap() {
         r#" Downloading ⠁ [00:0
 0:00] [-------------
 --------------------
--------] 0B/0B"#
+-------] 0 B/0 B"#
     );
 
     let new = min(downloaded + 223211, total_size);


### PR DESCRIPTION
*(I'm new to contributing, please be pedantic (but not opinionated) about the way I contribute.)*

The storage unit without prefix (B, but not KB, KiB...) is not separated from the number by a space, which is incorrect ([see 5.3.3 here](https://www.bipm.org/documents/20126/41483022/si_brochure_8.pdf)) and inconsistent with the formatting of prefixed units (KB, KiB...) in this library.

This is a ***breaking change*** and requires the modification of one test.