### PR TITLE
fix incorrect remainder calculation in RateLimiter

### DIFF
--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -427,7 +427,7 @@ impl RateLimiter {
         // convert into capacity now, so we're saving it for later.
         let (new, remainder) = (
             elapsed.as_millis() / self.interval as u128,
-            elapsed.as_nanos() % self.interval as u128 * 1_000_000,
+            elapsed.as_nanos() % (self.interval as u128 * 1_000_000),
         );
 
         // We add `new` to `capacity`, subtract one for returning `true` from here,


### PR DESCRIPTION
In `RateLimiter`, the remainder is calculated like this:

```rust
let (new, remainder) = (
    elapsed.as_millis() / self.interval as u128,
    elapsed.as_nanos() % self.interval as u128 * 1_000_000,
);
```

It looks like remainder is treated as milliseconds (`%` takes place prior to `*`). However, this seems off as it is shown later:

```rust
self.prev = now
    .checked_sub(Duration::from_nanos(remainder as u64))
    .unwrap();
```

`remainder` is actually used as nanoseconds.

By ~~removing the multiply~~ adjusting the order of calculation, it seems that the rate limiter is much more stable. See this MRE:

```rust
use std::time::Duration;

use indicatif::{ProgressDrawTarget, ProgressStyle};

fn main() {
    let pb = indicatif::ProgressBar::with_draw_target(Some(u64::MAX), ProgressDrawTarget::stdout_with_hz(1));
    pb.set_message(format!("Downloading"));
    pb.set_style(
        ProgressStyle::default_bar()
            .template("{msg}\n[{elapsed_precise}] {bytes}/{total_bytes}")
            .unwrap()
            .progress_chars("#>-"),
    );
    loop {
        pb.inc(1);
        std::thread::sleep(Duration::from_micros(1000));
    }
}
```

Before this fix:


https://github.com/console-rs/indicatif/assets/2109893/681e46ee-7a48-4c4f-87cd-18c088d68c4a



After this fix:


https://github.com/console-rs/indicatif/assets/2109893/8dfbb070-ccdf-4e35-9de2-154d137f6e0e

