### PR TITLE
Fixed progress bar not suspending multiprogress bar

### DIFF
--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -391,6 +391,8 @@ impl ProgressBar {
     ///
     /// Useful for external code that writes to the standard output.
     ///
+    /// If the progress bar was added to a MultiProgress, it will suspend the entire MultiProgress
+    ///
     /// **Note:** The internal lock is held while `f` is executed. Other threads trying to print
     /// anything on the progress bar will be blocked until `f` finishes.
     /// Therefore, it is recommended to avoid long-running operations in `f`.

--- a/src/state.rs
+++ b/src/state.rs
@@ -161,13 +161,17 @@ impl BarState {
     }
 
     pub(crate) fn suspend<F: FnOnce() -> R, R>(&mut self, now: Instant, f: F) -> R {
-        if let Some(drawable) = self.draw_target.drawable(true, now) {
-            let _ = drawable.clear();
-        }
+        if let Some((state, _)) = self.draw_target.remote() {
+            state.write().unwrap().suspend(f, now)
+        } else {
+            if let Some(drawable) = self.draw_target.drawable(true, now) {
+                let _ = drawable.clear();
+            }
 
-        let ret = f();
-        let _ = self.draw(true, Instant::now());
-        ret
+            let ret = f();
+            let _ = self.draw(true, Instant::now());
+            ret
+        }
     }
 
     pub(crate) fn draw(&mut self, mut force_draw: bool, now: Instant) -> io::Result<()> {

--- a/src/state.rs
+++ b/src/state.rs
@@ -162,16 +162,16 @@ impl BarState {
 
     pub(crate) fn suspend<F: FnOnce() -> R, R>(&mut self, now: Instant, f: F) -> R {
         if let Some((state, _)) = self.draw_target.remote() {
-            state.write().unwrap().suspend(f, now)
-        } else {
-            if let Some(drawable) = self.draw_target.drawable(true, now) {
-                let _ = drawable.clear();
-            }
-
-            let ret = f();
-            let _ = self.draw(true, Instant::now());
-            ret
+            return state.write().unwrap().suspend(f, now);
         }
+
+        if let Some(drawable) = self.draw_target.drawable(true, now) {
+            let _ = drawable.clear();
+        }
+
+        let ret = f();
+        let _ = self.draw(true, Instant::now());
+        ret
     }
 
     pub(crate) fn draw(&mut self, mut force_draw: bool, now: Instant) -> io::Result<()> {


### PR DESCRIPTION
When suspending a progress bar which is already inside a multiprogress bar, it should suspend the multiprogress bar.