### PR TITLE
added LogWrapper to bridge indicatif and the log crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ tokio = { version = "1", optional = true, features = ["io-util"] }
 unicode-segmentation = { version = "1", optional = true }
 unicode-width = { version = "0.1", optional = true }
 vt100 = { version = "0.15.1", optional = true }
+log = { version = "0.4.19", optional = true, features = ["std"] }
 
 [dev-dependencies]
 clap = { version = "4", features = ["color", "derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,6 +222,8 @@ mod format;
 #[cfg(feature = "in_memory")]
 mod in_memory;
 mod iter;
+#[cfg(feature = "log")]
+mod log;
 mod multi;
 mod progress_bar;
 #[cfg(feature = "rayon")]
@@ -238,6 +240,8 @@ pub use crate::format::{
 #[cfg(feature = "in_memory")]
 pub use crate::in_memory::InMemoryTerm;
 pub use crate::iter::{ProgressBarIter, ProgressIterator};
+#[cfg(feature = "log")]
+pub use crate::log::LogWrapper;
 pub use crate::multi::{MultiProgress, MultiProgressAlignment};
 pub use crate::progress_bar::{ProgressBar, WeakProgressBar};
 #[cfg(feature = "rayon")]

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,0 +1,60 @@
+use crate::MultiProgress;
+use log::Log;
+
+/// Wraps a MultiProgress and a Log implementor
+/// calling .suspend on the MultiProgress while writing the log message
+/// thereby preventing progress bars and logs from getting mixed up.
+///
+/// You simply have to add all the progress bars in use to the MultiProgress in use.
+pub struct LogWrapper<L: Log> {
+    bar: MultiProgress,
+    log: L,
+}
+
+impl<L: Log + 'static> LogWrapper<L> {
+    pub fn new(bar: MultiProgress, log: L) -> Self {
+        Self { bar, log }
+    }
+
+    /// installs this as the lobal logger,
+    ///
+    /// tries to find the correct argument to set_max_level
+    /// by reading the logger configuration,
+    /// you may want to set it manually though.
+    pub fn try_init(self) -> Result<(), log::SetLoggerError> {
+        use log::LevelFilter::*;
+        let levels = [Off, Error, Warn, Info, Debug, Trace];
+
+        for level_filter in levels.iter().rev() {
+            let level = if let Some(level) = level_filter.to_level() {
+                level
+            } else {
+                // off is the last level, just do nothing in that case
+                continue;
+            };
+            let meta = log::Metadata::builder().level(level).build();
+            if self.enabled(&meta) {
+                log::set_max_level(*level_filter);
+                break;
+            }
+        }
+
+        log::set_boxed_logger(Box::new(self))
+    }
+    pub fn multi(&self) -> MultiProgress {
+        self.bar.clone()
+    }
+}
+impl<L: Log> Log for LogWrapper<L> {
+    fn enabled(&self, metadata: &log::Metadata) -> bool {
+        self.log.enabled(metadata)
+    }
+
+    fn log(&self, record: &log::Record) {
+        self.bar.suspend(|| self.log.log(record))
+    }
+
+    fn flush(&self) {
+        self.log.flush()
+    }
+}


### PR DESCRIPTION
this is a much nicer solution than https://github.com/console-rs/indicatif/issues/566 and https://github.com/console-rs/indicatif/pull/567 in my opinion.

this is behind the "log" feature for now.
we could consider making this a default feature, it barely adds any code, does add the log crate as dependency though.