### PR TITLE
Add new Integrations section to README, containing a link to indicatif_log_bridge initially

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,6 @@ color support, but there are bigger plans for the future of this!
 
 [examples/single.rs](examples/single.rs)
 <img src="https://github.com/console-rs/indicatif/blob/main/screenshots/single.gif?raw=true">
+
+## Integrations
+You can use [indicatif\_log\_bridge](https://crates.io/crates/indicatif-log-bridge) to integrate with the [log crate](https://crates.io/crates/log) and avoid having both fight for your terminal.


### PR DESCRIPTION
discussed in https://github.com/console-rs/indicatif/pull/569

i tried writing an example too, but that leads to a circular dependency (indicatif_log_bridge depends on indicatif) and two "different" versions of MultiProgress being found, so that did not work out sadly.
