### PR TITLE
Document when `with_key` callbacks get invoked, and in which order

### DIFF
--- a/src/style.rs
+++ b/src/style.rs
@@ -150,6 +150,12 @@ impl ProgressStyle {
     }
 
     /// Adds a custom key that owns a [`ProgressTracker`] to the template
+    ///
+    /// The `ProgressTracker::write` method is called each time the key is referenced in the
+    /// template, in order with other formatting and computation in the template. The caller can
+    /// rely on this ordering.
+    ///
+    /// It's safe to call back into the `ProgressBar` from within this callback.
     pub fn with_key<S: ProgressTracker + 'static>(mut self, key: &'static str, f: S) -> Self {
         self.format_map.insert(key, Box::new(f));
         self


### PR DESCRIPTION
With some types of callbacks, it may matter what order the callbacks get
called in, and when in the formatting of the progress bar they're
called. For instance, if a `with_key` callback calls
`ProgressBar::set_position`, a *subsequent* reference to `eta` should
take that update into account.

Would appreciate having this documented as something callers can rely on.