### PR TITLE
allow padding HumanBytes Display output

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -109,8 +109,8 @@ const UNITS: &[(Duration, &str, &str)] = &[
 impl fmt::Display for HumanBytes {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match NumberPrefix::binary(self.0 as f64) {
-            NumberPrefix::Standalone(number) => write!(f, "{number:.0} B"),
-            NumberPrefix::Prefixed(prefix, number) => write!(f, "{number:.2} {prefix}B"),
+            NumberPrefix::Standalone(number) => f.pad(&format!("{number:.0} B")),
+            NumberPrefix::Prefixed(prefix, number) => f.pad(&format!("{number:.2} {prefix}B")),
         }
     }
 }


### PR DESCRIPTION
I've updated the `Display` implementation for `HumanBytes` so it can accept formatting parameters.