### PR TITLE
Fix attempt to subtract with overflow (#582)

### DIFF
--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -498,6 +498,7 @@ impl DrawState {
         let len = self.lines.len();
         let mut real_len = 0;
         let mut last_line_filler = 0;
+        debug_assert!(self.orphan_lines_count <= self.lines.len());
         for (idx, line) in self.lines.iter().enumerate() {
             let line_width = console::measure_text_width(line);
             let diff = if line.is_empty() {
@@ -514,7 +515,11 @@ impl DrawState {
                 // subtract with overflow later.
                 usize::max(terminal_len, 1)
             };
-            if real_len + diff > term_height {
+            // Don't consider orphan lines when comparing to terminal height.
+            debug_assert!(idx <= real_len);
+            if self.orphan_lines_count <= idx
+                && real_len - self.orphan_lines_count + diff > term_height
+            {
                 break;
             }
             real_len += diff;

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -1804,13 +1804,15 @@ fn orphan_lines_message_above_progress_bar() {
         let n = 5 + i;
 
         // Test with messages of differing numbers of lines. The messages have the form:
-        // n - 1 newlines followed by the number `n`. The value of n ranges from 5 (less
-        // than the terminal height) to 15 (greater than the terminal height).
-        pb.println(format!("{}{n}", "\n".repeat(n - 1)));
+        // n - 1 newlines followed by n * 11 dashes (`-`). The value of n ranges from 5
+        // (less than the terminal height) to 15 (greater than the terminal height). The
+        // number 11 is intentionally not a factor of the terminal width (80), but large
+        // enough that the strings of dashes should eventually wrap.
+        pb.println(format!("{}{}", "\n".repeat(n - 1), "-".repeat(n * 11)));
 
         // Check that the line above the progress bar is the number `n`.
         assert_eq!(
-            format!("{n}"),
+            format!("{}", "-".repeat(n * 11 % 80)),
             in_mem.contents().lines().rev().nth(1).unwrap(),
         );
     }

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -1780,8 +1780,7 @@ fn orphan_lines() {
 
         let n = 5 + i;
 
-        let msg = std::iter::repeat('\n').take(n).collect::<String>();
-        pb.println(msg);
+        pb.println("\n".repeat(n));
     }
 
     pb.finish();
@@ -1807,16 +1806,12 @@ fn orphan_lines_message_above_progress_bar() {
         // Test with messages of differing numbers of lines. The messages have the form:
         // n - 1 newlines followed by the number `n`. The value of n ranges from 5 (less
         // than the terminal height) to 15 (greater than the terminal height).
-        let msg = std::iter::repeat(String::from("\n"))
-            .take(n - 1)
-            .chain(std::iter::once(format!("{n}")))
-            .collect::<String>();
-        pb.println(msg);
+        pb.println(format!("{}{n}", "\n".repeat(n - 1)));
 
         // Check that the line above the progress bar is the number `n`.
         assert_eq!(
             format!("{n}"),
-            in_mem.contents().lines().rev().skip(1).next().unwrap(),
+            in_mem.contents().lines().rev().nth(1).unwrap(),
         );
     }
 

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -1762,3 +1762,63 @@ Flush
 "#
     );
 }
+
+#[test]
+fn orphan_lines() {
+    let in_mem = InMemoryTerm::new(10, 80);
+
+    let pb = ProgressBar::with_draw_target(
+        Some(10),
+        ProgressDrawTarget::term_like(Box::new(in_mem.clone())),
+    );
+    assert_eq!(in_mem.contents(), String::new());
+
+    for i in 0..=10 {
+        if i != 0 {
+            pb.inc(1);
+        }
+
+        let n = 5 + i;
+
+        let msg = std::iter::repeat('\n').take(n).collect::<String>();
+        pb.println(msg);
+    }
+
+    pb.finish();
+}
+
+#[test]
+fn orphan_lines_message_above_progress_bar() {
+    let in_mem = InMemoryTerm::new(10, 80);
+
+    let pb = ProgressBar::with_draw_target(
+        Some(10),
+        ProgressDrawTarget::term_like(Box::new(in_mem.clone())),
+    );
+    assert_eq!(in_mem.contents(), String::new());
+
+    for i in 0..=10 {
+        if i != 0 {
+            pb.inc(1);
+        }
+
+        let n = 5 + i;
+
+        // Test with messages of differing numbers of lines. The messages have the form:
+        // n - 1 newlines followed by the number `n`. The value of n ranges from 5 (less
+        // than the terminal height) to 15 (greater than the terminal height).
+        let msg = std::iter::repeat(String::from("\n"))
+            .take(n - 1)
+            .chain(std::iter::once(format!("{n}")))
+            .collect::<String>();
+        pb.println(msg);
+
+        // Check that the line above the progress bar is the number `n`.
+        assert_eq!(
+            format!("{n}"),
+            in_mem.contents().lines().rev().skip(1).next().unwrap(),
+        );
+    }
+
+    pb.finish();
+}

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -1807,10 +1807,11 @@ fn orphan_lines_message_above_progress_bar() {
         // n - 1 newlines followed by n * 11 dashes (`-`). The value of n ranges from 5
         // (less than the terminal height) to 15 (greater than the terminal height). The
         // number 11 is intentionally not a factor of the terminal width (80), but large
-        // enough that the strings of dashes should eventually wrap.
+        // enough that the strings of dashes eventually wrap.
         pb.println(format!("{}{}", "\n".repeat(n - 1), "-".repeat(n * 11)));
 
-        // Check that the line above the progress bar is the number `n`.
+        // Check that the line above the progress bar is a string of dashes of length
+        // n * 11 mod the terminal width.
         assert_eq!(
             format!("{}", "-".repeat(n * 11 % 80)),
             in_mem.contents().lines().rev().nth(1).unwrap(),


### PR DESCRIPTION
Fixes #582 

The test `orphan_lines` reproduces the panic. The test `orphan_lines_message_above_progress_bar` tries to ensure that messages are still printed correctly following the fix.

The proposed fix is to effectively ignore `self.orphan_lines_count` many lines from `real_len` when comparing `real_len` to the terminal height.

@oli-obk Would you be able to glance at this? :pray: