### PR TITLE
docs: Improve formatting and linking.

### DIFF
--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -66,7 +66,7 @@ impl ProgressDrawTarget {
     /// hidden.  This is done so that piping to a file will not produce
     /// useless escape codes in that file.
     ///
-    /// Will panic if refresh_rate is `0`.
+    /// Will panic if `refresh_rate` is `0`.
     pub fn term(term: Term, refresh_rate: u8) -> Self {
         Self {
             kind: TargetKind::Term {

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -66,7 +66,7 @@ pub struct ProgressBarIter<T> {
 impl<T> ProgressBarIter<T> {
     /// Builder-like function for setting underlying progress bar's style.
     ///
-    /// See [ProgressBar::with_style].
+    /// See [`ProgressBar::with_style`].
     pub fn with_style(mut self, style: ProgressStyle) -> Self {
         self.progress = self.progress.with_style(style);
         self
@@ -74,7 +74,7 @@ impl<T> ProgressBarIter<T> {
 
     /// Builder-like function for setting underlying progress bar's prefix.
     ///
-    /// See [ProgressBar::with_prefix].
+    /// See [`ProgressBar::with_prefix`].
     pub fn with_prefix(mut self, prefix: impl Into<Cow<'static, str>>) -> Self {
         self.progress = self.progress.with_prefix(prefix);
         self
@@ -82,7 +82,7 @@ impl<T> ProgressBarIter<T> {
 
     /// Builder-like function for setting underlying progress bar's message.
     ///
-    /// See [ProgressBar::with_message].
+    /// See [`ProgressBar::with_message`].
     pub fn with_message(mut self, message: impl Into<Cow<'static, str>>) -> Self {
         self.progress = self.progress.with_message(message);
         self
@@ -90,7 +90,7 @@ impl<T> ProgressBarIter<T> {
 
     /// Builder-like function for setting underlying progress bar's position.
     ///
-    /// See [ProgressBar::with_position].
+    /// See [`ProgressBar::with_position`].
     pub fn with_position(mut self, position: u64) -> Self {
         self.progress = self.progress.with_position(position);
         self
@@ -98,7 +98,7 @@ impl<T> ProgressBarIter<T> {
 
     /// Builder-like function for setting underlying progress bar's elapsed time.
     ///
-    /// See [ProgressBar::with_elapsed].
+    /// See [`ProgressBar::with_elapsed`].
     pub fn with_elapsed(mut self, elapsed: Duration) -> Self {
         self.progress = self.progress.with_elapsed(elapsed);
         self
@@ -106,7 +106,7 @@ impl<T> ProgressBarIter<T> {
 
     /// Builder-like function for setting underlying progress bar's finish behavior.
     ///
-    /// See [ProgressBar::with_finish].
+    /// See [`ProgressBar::with_finish`].
     pub fn with_finish(mut self, finish: ProgressFinish) -> Self {
         self.progress = self.progress.with_finish(finish);
         self

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -26,8 +26,11 @@ impl MultiProgress {
     /// Creates a new multi progress object.
     ///
     /// Progress bars added to this object by default draw directly to stderr, and refresh
-    /// a maximum of 15 times a second. To change the refresh rate set the draw target to
+    /// a maximum of 15 times a second. To change the refresh rate [set] the [draw target] to
     /// one with a different refresh rate.
+    ///
+    /// [set]: MultiProgress::set_draw_target
+    /// [draw target]: ProgressDrawTarget
     pub fn new() -> Self {
         Self::default()
     }
@@ -40,6 +43,8 @@ impl MultiProgress {
     }
 
     /// Sets a different draw target for the multiprogress bar.
+    ///
+    /// Use [`MultiProgress::with_draw_target`] to set the draw target during creation.
     pub fn set_draw_target(&self, target: ProgressDrawTarget) {
         let mut state = self.state.write().unwrap();
         state.draw_target.disconnect(Instant::now());

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -38,8 +38,11 @@ impl ProgressBar {
     /// Creates a new progress bar with a given length
     ///
     /// This progress bar by default draws directly to stderr, and refreshes a maximum of 15 times
-    /// a second. To change the refresh rate, set the draw target to one with a different refresh
+    /// a second. To change the refresh rate, [set] the [draw target] to one with a different refresh
     /// rate.
+    ///
+    /// [set]: ProgressBar::set_draw_target
+    /// [draw target]: ProgressDrawTarget
     pub fn new(len: u64) -> Self {
         Self::with_draw_target(Some(len), ProgressDrawTarget::stderr())
     }
@@ -378,6 +381,8 @@ impl ProgressBar {
     /// running [`MultiProgress::add`]) will unlink this progress bar. If you don't want this
     /// behavior, call [`MultiProgress::set_draw_target`] instead.
     ///
+    /// Use [`ProgressBar::with_draw_target`] to set the draw target during creation.
+    ///
     /// [`MultiProgress`]: crate::MultiProgress
     /// [`MultiProgress::add`]: crate::MultiProgress::add
     /// [`MultiProgress::set_draw_target`]: crate::MultiProgress::set_draw_target
@@ -391,7 +396,7 @@ impl ProgressBar {
     ///
     /// Useful for external code that writes to the standard output.
     ///
-    /// If the progress bar was added to a MultiProgress, it will suspend the entire MultiProgress
+    /// If the progress bar was added to a [`MultiProgress`], it will suspend the entire `MultiProgress`].
     ///
     /// **Note:** The internal lock is held while `f` is executed. Other threads trying to print
     /// anything on the progress bar will be blocked until `f` finishes.
@@ -404,6 +409,8 @@ impl ProgressBar {
     ///     println!("Log message");
     /// })
     /// ```
+    ///
+    /// [`MultiProgress`]: crate::MultiProgress
     pub fn suspend<F: FnOnce() -> R, R>(&self, f: F) -> R {
         self.state().suspend(Instant::now(), f)
     }


### PR DESCRIPTION
Using `clippy::doc_markdown` showed a couple of minor issues with the docs and then the rest were via visual inspection.