### PR TITLE
Add minimal examples demonstrating Formatters

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -19,14 +19,47 @@ pub struct FormattedDuration(pub Duration);
 pub struct HumanDuration(pub Duration);
 
 /// Formats bytes for human readability
+///
+/// # Examples
+/// ```rust
+/// # use indicatif::HumanBytes;
+/// assert_eq!("15 B",     format!("{}", HumanBytes(15)));
+/// assert_eq!("1.46 KiB", format!("{}", HumanBytes(1_500)));
+/// assert_eq!("1.43 MiB", format!("{}", HumanBytes(1_500_000)));
+/// assert_eq!("1.40 GiB", format!("{}", HumanBytes(1_500_000_000)));
+/// assert_eq!("1.36 TiB", format!("{}", HumanBytes(1_500_000_000_000)));
+/// assert_eq!("1.33 PiB", format!("{}", HumanBytes(1_500_000_000_000_000)));
+/// ```
 #[derive(Debug)]
 pub struct HumanBytes(pub u64);
 
 /// Formats bytes for human readability using SI prefixes
+///
+/// # Examples
+/// ```rust
+/// # use indicatif::DecimalBytes;
+/// assert_eq!("15 B",    format!("{}", DecimalBytes(15)));
+/// assert_eq!("1.50 kB", format!("{}", DecimalBytes(1_500)));
+/// assert_eq!("1.50 MB", format!("{}", DecimalBytes(1_500_000)));
+/// assert_eq!("1.50 GB", format!("{}", DecimalBytes(1_500_000_000)));
+/// assert_eq!("1.50 TB", format!("{}", DecimalBytes(1_500_000_000_000)));
+/// assert_eq!("1.50 PB", format!("{}", DecimalBytes(1_500_000_000_000_000)));
+/// ```
 #[derive(Debug)]
 pub struct DecimalBytes(pub u64);
 
 /// Formats bytes for human readability using ISO/IEC prefixes
+///
+/// # Examples
+/// ```rust
+/// # use indicatif::BinaryBytes;
+/// assert_eq!("15 B",     format!("{}", BinaryBytes(15)));
+/// assert_eq!("1.46 KiB", format!("{}", BinaryBytes(1_500)));
+/// assert_eq!("1.43 MiB", format!("{}", BinaryBytes(1_500_000)));
+/// assert_eq!("1.40 GiB", format!("{}", BinaryBytes(1_500_000_000)));
+/// assert_eq!("1.36 TiB", format!("{}", BinaryBytes(1_500_000_000_000)));
+/// assert_eq!("1.33 PiB", format!("{}", BinaryBytes(1_500_000_000_000_000)));
+/// ```
 #[derive(Debug)]
 pub struct BinaryBytes(pub u64);
 


### PR DESCRIPTION
This change adds some doc tests to show off what the formatter looks like. This change adds it for just the byte variants:
- `HumanBytes`, which seems to forward to `BinaryBytes`?
- `DecimalBytes`, 1 MB == 1 * 10**6 bytes
- `BinaryBytes`, 1 MiB == 1 * (1 << 20) bytes

I wanted to know what these formatters *look like*, preferably from the docs. This is the simplest way that comes to mind, but I'm open to doing this differently if there's alternatives. I only did the Byte variants with this. I'm happy to work on the others but want to make sure this direction is accepted first.

Here's what my local `rustdoc` docs look like after this change:
<img width="1055" alt="image" src="https://github.com/console-rs/indicatif/assets/1052157/25864d94-3e84-4c64-a948-5541af776b13">

These also double as tests, and `cargo test` will fail if their behavior changes.