### PR TITLE
Use current position for calculating finished progress bar per_sec instead of bar length

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -311,8 +311,7 @@ impl ProgressState {
         if let Status::InProgress = self.status {
             self.est.steps_per_second(Instant::now())
         } else {
-            let len = self.len.unwrap_or_else(|| self.pos());
-            len as f64 / self.started.elapsed().as_secs_f64()
+            self.pos() as f64 / self.started.elapsed().as_secs_f64()
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/console-rs/indicatif/issues/601