### PR TITLE
fix and rename `real_len`

### DIFF
--- a/src/multi.rs
+++ b/src/multi.rs
@@ -519,17 +519,16 @@ enum InsertLocation {
     Before(usize),
 }
 
-// Calculate real length based on terminal width
-// This take in account linewrap from terminal
-fn visual_line_count<StrRef: AsRef<str>>(lines: &[StrRef], width: f64) -> usize {
-    lines.iter().fold(0, |sum, val| {
-        sum + if val.as_ref().is_empty() {
-            1
-        } else {
-            let effective_line_length = console::measure_text_width(val.as_ref()) as f64;
-            usize::max((effective_line_length / width).ceil() as usize, 1)
-        }
-    })
+/// Calculate the number of visual lines in the given lines, after
+/// accounting for line wrapping and non-printable characters.
+fn visual_line_count(lines: &[impl AsRef<str>], width: f64) -> usize {
+    let mut real_lines = 0;
+    for line in lines {
+        let effective_line_length = console::measure_text_width(line.as_ref()) as f64;
+        real_lines += usize::max((effective_line_length / width).ceil() as usize, 1);
+    }
+
+    real_lines
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes #606 -- see added test cases. This logic matches what happens `draw_target.rs` as well. It'll now also correctly handle lines with only ANSI codes.

https://github.com/console-rs/indicatif/blob/81aa4c65d7202128d471b3a452a0236e03f3bc43/src/draw_target.rs#L505-L518