### PR TITLE
Moved from unicode-width to unicode-display-width for visual grapheme width estimation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indicatif"
-version = "0.17.8"
+version = "0.17.9"
 edition = "2021"
 rust-version = "1.63"
 description = "A progress bar and cli reporting library for Rust"
@@ -13,14 +13,14 @@ readme = "README.md"
 exclude = ["screenshots/*"]
 
 [dependencies]
-console = { version = "0.15", default-features = false, features = ["ansi-parsing"] }
+console = { version = "0.16", default-features = false, features = ["ansi-parsing"] }
 futures-core = { version = "0.3", default-features = false, optional = true }
 number_prefix = "0.4"
 portable-atomic = "1.0.0"
 rayon = { version = "1.1", optional = true }
 tokio = { version = "1", optional = true, features = ["io-util"] }
+unicode-display-width = { version = "0.3", optional = true }
 unicode-segmentation = { version = "1", optional = true }
-unicode-width = { version = "0.1", optional = true }
 vt100 = { version = "0.15.1", optional = true }
 
 [dev-dependencies]
@@ -35,8 +35,8 @@ pretty_assertions = "1.4.0"
 instant = "0.1"
 
 [features]
-default = ["unicode-width", "console/unicode-width"]
-improved_unicode = ["unicode-segmentation", "unicode-width", "console/unicode-width"]
+default = ["unicode-display-width", "console/unicode-display-width"]
+improved_unicode = ["unicode-segmentation", "unicode-display-width", "console/unicode-display-width"]
 in_memory = ["vt100"]
 futures = ["dep:futures-core"]
 

--- a/examples/cargo.rs
+++ b/examples/cargo.rs
@@ -14,7 +14,7 @@ static CRATES: &[(&str, &str)] = &[
     ("regex-syntax", "v0.6.23"),
     ("terminal_size", "v0.1.16"),
     ("libc", "v0.2.93"),
-    ("unicode-width", "v0.1.8"),
+    ("unicode-display-width", "v0.3.0"),
     ("lazy_static", "v1.4.0"),
     ("number_prefix", "v0.4.0"),
     ("regex", "v1.4.6"),

--- a/src/style.rs
+++ b/src/style.rs
@@ -39,12 +39,12 @@ fn segment(s: &str) -> Vec<Box<str>> {
     s.chars().map(|x| x.to_string().into()).collect()
 }
 
-#[cfg(feature = "unicode-width")]
+#[cfg(feature = "unicode-display-width")]
 fn measure(s: &str) -> usize {
-    unicode_width::UnicodeWidthStr::width(s)
+    unicode_display_width::width(s) as usize
 }
 
-#[cfg(not(feature = "unicode-width"))]
+#[cfg(not(feature = "unicode-display-width"))]
 fn measure(s: &str) -> usize {
     s.chars().count()
 }


### PR DESCRIPTION
This change had to be made in both crates in order to be updated correctly.
The console-rs crate has been bumped an extra version as a result of a behavior change of `char_width()` with the `unicode-display-width` feature enabled - it now returns always 1 or 2, never 0 as it used to.
The indicatif crate may also need to be bumped a full version as a result of the dependency change, but I'm not sure if you'd consider this a breaking change to the same degree, as it's not an advertised feature.

Related issue: https://github.com/console-rs/indicatif/issues/638
Related PR: https://github.com/console-rs/console/pull/210