### PR TITLE
tests: print whether colors are enabled to help diagnose spurious failure

### DIFF
--- a/src/style.rs
+++ b/src/style.rs
@@ -779,6 +779,7 @@ mod tests {
 
     use super::*;
     use crate::state::{AtomicPosition, ProgressState};
+    use console::colors_enabled;
     use std::sync::Mutex;
 
     #[test]
@@ -925,6 +926,8 @@ mod tests {
 
     #[test]
     fn wide_element_style() {
+        println!("colors_enabled: {}", colors_enabled());
+
         const CHARS: &str = "=>-";
         const WIDTH: u16 = 8;
         let pos = Arc::new(AtomicPosition::new());


### PR DESCRIPTION
See for example https://github.com/console-rs/indicatif/actions/runs/8844253603. 

The only thing I can think off is that `colors_enabled` is returning `false`, leading to the unstyled output. If so, this would suggest some kind of race, e.g. in https://github.com/console-rs/console/blob/master/src/utils.rs#L39. But before we go down that rabbit hole let's test the basic theory.