### PR TITLE
Documentation tweaks; bump MSRV

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.63"
+          toolchain: "1.70"
       - run: cargo check --lib --all-features
   lint:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "indicatif"
 version = "0.17.8"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.70"
 description = "A progress bar and cli reporting library for Rust"
 keywords = ["cli", "progress", "pb", "colors", "progressbar"]
 categories = ["command-line-interface"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,20 +176,19 @@
 //! * `bar`: renders a progress bar. By default 20 characters wide.  The
 //!   style string is used to color the elapsed part, the alternative
 //!   style is used for the bar that is yet to render.
-//! * `wide_bar`: like `bar` but always fills the remaining space. It should not be used with
-//! `wide_msg`.
+//! * `wide_bar`: like `bar` but always fills the remaining space. It should not be used with `wide_msg`.
 //! * `spinner`: renders the spinner (current tick string). Note that spinners do not automatically tick by default. You either
-//! need to call `enable_steady_tick` or manually call `tick`.
+//!   need to call `enable_steady_tick` or manually call `tick`.
 //! * `prefix`: renders the prefix set on the progress bar.
 //! * `msg`: renders the currently set message on the progress bar.
 //! * `wide_msg`: like `msg` but always fills the remaining space and truncates. It should not be used
-//! with `wide_bar`.
+//!   with `wide_bar`.
 //! * `pos`: renders the current position of the bar as integer
 //! * `human_pos`: renders the current position of the bar as an integer, with commas as the
-//! thousands separator.
+//!   thousands separator.
 //! * `len`: renders the amount of work to be done as an integer
 //! * `human_len`: renders the total length of the bar as an integer, with commas as the thousands
-//! separator.
+//!   separator.
 //! * `percent`: renders the current position of the bar as a percentage of the total length (as an integer).
 //! * `percent_precise`: renders the current position of the bar as a percentage of the total length (with 3 fraction digits).
 //! * `bytes`: renders the current position of the bar as bytes (alias of `binary_bytes`).

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -37,7 +37,7 @@ impl fmt::Debug for ProgressBar {
 impl ProgressBar {
     /// Creates a new progress bar with a given length
     ///
-    /// This progress bar by default draws directly to stderr, and refreshes a maximum of 15 times
+    /// This progress bar by default draws directly to stderr, and refreshes a maximum of 20 times
     /// a second. To change the refresh rate, [set] the [draw target] to one with a different refresh
     /// rate.
     ///


### PR DESCRIPTION
1. Fix lint failures
2. The default refresh rate is 20 Hz, not 15 Hz as claimed in `ProgressBar::new` documentation
3. Bump MSRV to 1.70 for Tokio 1.39.2