### PR TITLE
Fix bar-less text output

### DIFF
--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -511,7 +511,6 @@ impl DrawState {
             _ => VisualLines::default(),
         };
 
-        let term_height = term.height() as usize;
         let term_width = term.width() as usize;
         debug_assert!(self.orphan_lines_count <= self.lines.len());
         let orphan_visual_line_count =
@@ -540,7 +539,7 @@ impl DrawState {
                 // If so, then `real_len` should be at least `orphan_visual_line_count`.
                 debug_assert!(orphan_visual_line_count <= real_len);
                 // Don't consider orphan lines when comparing to terminal height.
-                if real_len - orphan_visual_line_count + diff > term_height.into() {
+                if real_len - orphan_visual_line_count + diff > term.height().into() {
                     break;
                 }
             }

--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -543,18 +543,14 @@ impl DrawState {
             let line_height = line.wrapped_height(term_width);
 
             // Check here for bar lines that exceed the terminal height
-            if text_line_count <= idx {
-                // If all the orphan lines have been drawn, then `real_height` should be
-                // at least `orphan_visual_line_count`.
-                debug_assert!(text_height <= real_height);
-
-                // Don't consider orphan lines when comparing to terminal height.
-                if real_height - text_height + line_height > term.height().into() {
+            if matches!(line, LineType::Bar(_)) {
+                // Stop here if printing this bar would exceed the terminal height
+                if real_height + line_height > term.height().into() {
                     break;
                 }
-            }
 
-            real_height += line_height;
+                real_height += line_height;
+            }
 
             // Print a new line if this is not the first line printed this tick
             // the first line will automatically wrap due to the filler below
@@ -573,7 +569,7 @@ impl DrawState {
         }
 
         term.flush()?;
-        *bar_count = real_height - text_height + shift;
+        *bar_count = real_height + shift;
 
         Ok(())
     }

--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -505,21 +505,8 @@ impl DrawState {
 
         let term_width = term.width() as usize;
 
-        // The number of text lines that are contained in this draw state
-        let text_line_count = self
-            .lines
-            .iter()
-            .filter(|line| matches!(line, LineType::Text(_) | LineType::Empty))
-            .count();
-
-        // Here we calculate the terminal vertical height each of those groups require when
-        // printing, taking wrapping into account.
-        let text_height = self.visual_line_count(..text_line_count, term_width);
-        let bar_height = self.visual_line_count(text_line_count.., term_width);
+        // Here we calculate the terminal vertical real estate that the state requires
         let full_height = self.visual_line_count(.., term_width);
-
-        // Sanity checks
-        debug_assert!(full_height == text_height + bar_height);
 
         let shift = match self.alignment {
             // If we align to the bottom and the new height is less than before, clear the lines

--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -507,15 +507,15 @@ impl DrawState {
         // printing, taking wrapping into account.
         let orphan_visual_line_count = self.visual_line_count(..text_line_count, term_width);
         let bar_height = self.visual_line_count(text_line_count.., term_width);
-        let visual_lines = self.visual_line_count(.., term_width);
+        let full_height = self.visual_line_count(.., term_width);
 
         // Sanity checks
-        debug_assert!(visual_lines == orphan_visual_line_count + bar_height);
+        debug_assert!(full_height == orphan_visual_line_count + bar_height);
         debug_assert!(self.orphan_lines_count <= self.lines.len());
 
         let shift = match self.alignment {
-            MultiProgressAlignment::Bottom if visual_lines < *last_line_count => {
-                let shift = *last_line_count - visual_lines;
+            MultiProgressAlignment::Bottom if full_height < *last_line_count => {
+                let shift = *last_line_count - full_height;
                 for _ in 0..shift.as_usize() {
                     term.write_line("")?;
                 }

--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -505,12 +505,12 @@ impl DrawState {
 
         // Here we calculate the terminal vertical height each of those groups require when
         // printing, taking wrapping into account.
-        let orphan_visual_line_count = self.visual_line_count(..text_line_count, term_width);
+        let text_height = self.visual_line_count(..text_line_count, term_width);
         let bar_height = self.visual_line_count(text_line_count.., term_width);
         let full_height = self.visual_line_count(.., term_width);
 
         // Sanity checks
-        debug_assert!(full_height == orphan_visual_line_count + bar_height);
+        debug_assert!(full_height == text_height + bar_height);
         debug_assert!(self.orphan_lines_count <= self.lines.len());
 
         let shift = match self.alignment {
@@ -547,10 +547,10 @@ impl DrawState {
             .into();
             // Have all orphan lines been drawn?
             if self.orphan_lines_count <= idx {
-                // If so, then `real_len` should be at least `orphan_visual_line_count`.
-                debug_assert!(orphan_visual_line_count <= real_len);
+                // If so, then `real_height` should be at least `text_height`.
+                debug_assert!(text_height <= real_height);
                 // Don't consider orphan lines when comparing to terminal height.
-                if real_len - orphan_visual_line_count + diff > term.height().into() {
+                if real_height - text_height + diff > term.height().into() {
                     break;
                 }
             }

--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -513,7 +513,6 @@ impl DrawState {
 
         let term_height = term.height() as usize;
         let term_width = term.width() as usize;
-        let len = self.lines.len();
         debug_assert!(self.orphan_lines_count <= self.lines.len());
         let orphan_visual_line_count =
             self.visual_line_count(..self.orphan_lines_count, term_width);
@@ -550,7 +549,7 @@ impl DrawState {
                 term.write_line("")?;
             }
             term.write_str(line)?;
-            if idx + 1 == len {
+            if idx + 1 == self.lines.len() {
                 // Keep the cursor on the right terminal side
                 // So that next user writes/prints will happen on the next line
                 last_line_filler = term_width.saturating_sub(line_width);

--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -526,7 +526,8 @@ impl DrawState {
 
         // Accumulate the displayed height in here. This differs from `full_height` in that it will
         // not reflect the displayed content if the terminal height is exceeded.
-        let mut real_len = VisualLines::default();
+        let mut real_height = VisualLines::default();
+
         for (idx, line) in self.lines.iter().enumerate() {
             let line_width = console::measure_text_width(line);
             let diff = if line.is_empty() {
@@ -544,6 +545,7 @@ impl DrawState {
                 usize::max(terminal_len, 1)
             }
             .into();
+
             // Have all orphan lines been drawn?
             if self.orphan_lines_count <= idx {
                 // If so, then `real_height` should be at least `orphan_visual_line_count`.
@@ -553,11 +555,14 @@ impl DrawState {
                     break;
                 }
             }
-            real_len += diff;
+
+            real_height += diff;
             if idx != 0 {
                 term.write_line("")?;
             }
+
             term.write_str(line)?;
+
             if idx + 1 == self.lines.len() {
                 // Keep the cursor on the right terminal side
                 // So that next user writes/prints will happen on the next line

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -6,7 +6,8 @@ use std::thread::panicking;
 use std::time::Instant;
 
 use crate::draw_target::{
-    visual_line_count, DrawState, DrawStateWrapper, LineAdjust, ProgressDrawTarget, VisualLines,
+    visual_line_count, DrawState, DrawStateWrapper, LineAdjust, LineType, ProgressDrawTarget,
+    VisualLines,
 };
 use crate::progress_bar::ProgressBar;
 #[cfg(target_arch = "wasm32")]
@@ -217,7 +218,7 @@ pub(crate) struct MultiState {
     alignment: MultiProgressAlignment,
     /// Lines to be drawn above everything else in the MultiProgress. These specifically come from
     /// calling `ProgressBar::println` on a pb that is connected to a `MultiProgress`.
-    orphan_lines: Vec<String>,
+    orphan_lines: Vec<LineType>,
     /// The count of currently visible zombie lines.
     zombie_lines_count: VisualLines,
 }
@@ -267,7 +268,7 @@ impl MultiState {
     pub(crate) fn draw(
         &mut self,
         mut force_draw: bool,
-        extra_lines: Option<Vec<String>>,
+        extra_lines: Option<Vec<LineType>>,
         now: Instant,
     ) -> io::Result<()> {
         if panicking() {
@@ -365,9 +366,9 @@ impl MultiState {
         let msg = msg.as_ref();
 
         // If msg is "", make sure a line is still printed
-        let lines: Vec<String> = match msg.is_empty() {
-            false => msg.lines().map(Into::into).collect(),
-            true => vec![String::new()],
+        let lines: Vec<LineType> = match msg.is_empty() {
+            false => msg.lines().map(|l| LineType::Text(Into::into(l))).collect(),
+            true => vec![LineType::Empty],
         };
 
         self.draw(true, Some(lines), now)

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -327,12 +327,10 @@ impl MultiState {
         };
 
         let mut draw_state = drawable.state();
-        draw_state.orphan_lines_count = self.orphan_lines.len();
         draw_state.alignment = self.alignment;
 
         if let Some(extra_lines) = &extra_lines {
             draw_state.lines.extend_from_slice(extra_lines.as_slice());
-            draw_state.orphan_lines_count += extra_lines.len();
         }
 
         // Add lines from `ProgressBar::println` call.

--- a/src/state.rs
+++ b/src/state.rs
@@ -152,7 +152,6 @@ impl BarState {
             draw_state.lines.extend(lines);
         }
 
-        draw_state.orphan_lines_count = draw_state.lines.len();
         if let Some(width) = width {
             if !matches!(self.state.status, Status::DoneHidden) {
                 self.style

--- a/src/state.rs
+++ b/src/state.rs
@@ -9,7 +9,7 @@ use std::time::Instant;
 use instant::Instant;
 use portable_atomic::{AtomicU64, AtomicU8, Ordering};
 
-use crate::draw_target::ProgressDrawTarget;
+use crate::draw_target::{LineType, ProgressDrawTarget};
 use crate::style::ProgressStyle;
 
 pub(crate) struct BarState {
@@ -144,10 +144,10 @@ impl BarState {
         };
 
         let mut draw_state = drawable.state();
-        let lines: Vec<String> = msg.lines().map(Into::into).collect();
+        let lines: Vec<LineType> = msg.lines().map(|l| LineType::Text(Into::into(l))).collect();
         // Empty msg should trigger newline as we are in println
         if lines.is_empty() {
-            draw_state.lines.push(String::new());
+            draw_state.lines.push(LineType::Empty);
         } else {
             draw_state.lines.extend(lines);
         }

--- a/src/style.rs
+++ b/src/style.rs
@@ -10,6 +10,7 @@ use instant::Instant;
 #[cfg(feature = "unicode-segmentation")]
 use unicode_segmentation::UnicodeSegmentation;
 
+use crate::draw_target::LineType;
 use crate::format::{
     BinaryBytes, DecimalBytes, FormattedDuration, HumanBytes, HumanCount, HumanDuration,
     HumanFloatCount,
@@ -226,7 +227,7 @@ impl ProgressStyle {
     pub(crate) fn format_state(
         &self,
         state: &ProgressState,
-        lines: &mut Vec<String>,
+        lines: &mut Vec<LineType>,
         target_width: u16,
     ) {
         let mut cur = String::new();
@@ -374,9 +375,10 @@ impl ProgressStyle {
         }
     }
 
+    /// This is used exclusively to add the bars built above to the lines to print
     fn push_line(
         &self,
-        lines: &mut Vec<String>,
+        lines: &mut Vec<LineType>,
         cur: &mut String,
         state: &ProgressState,
         buf: &mut String,
@@ -394,11 +396,11 @@ impl ProgressStyle {
         for (i, line) in expanded.split('\n').enumerate() {
             // No newlines found in this case
             if i == 0 && line.len() == expanded.len() {
-                lines.push(expanded);
+                lines.push(LineType::Bar(expanded));
                 break;
             }
 
-            lines.push(line.to_string());
+            lines.push(LineType::Bar(line.to_string()));
         }
     }
 }

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -1288,7 +1288,6 @@ Str("⠁ 1")
 Str("")
 NewLine
 Str("⠁ 2")
-Str("")
 Flush
 Up(3)
 Clear
@@ -1309,7 +1308,6 @@ Str("⠁ 1")
 Str("")
 NewLine
 Str("⠁ 2")
-Str("")
 Flush
 Up(3)
 Clear
@@ -1330,7 +1328,6 @@ Str("⠁ 1")
 Str("")
 NewLine
 Str("⠁ 2")
-Str("")
 Flush
 Up(3)
 Clear
@@ -1351,7 +1348,6 @@ Str("⠁ 1")
 Str("")
 NewLine
 Str("⠁ 2")
-Str("")
 Flush
 "#
     );
@@ -1387,7 +1383,6 @@ Str("⠁ 1")
 Str("")
 NewLine
 Str("⠁ 2")
-Str("")
 Flush
 "#
     );
@@ -1414,7 +1409,6 @@ Str("⠁ 3")
 Str("")
 NewLine
 Str("⠁ 4")
-Str("")
 Flush
 Up(3)
 Clear
@@ -1435,7 +1429,6 @@ Str("⠁ 4")
 Str("")
 NewLine
 Str("⠁ 5")
-Str("")
 Flush
 Up(3)
 Clear
@@ -1498,7 +1491,6 @@ Str("⠁ 6")
 Str("                                                                             ")
 Flush
 Clear
-Str("")
 Flush
 "#
     );
@@ -1608,7 +1600,6 @@ Str("⠁ 1")
 Str("")
 NewLine
 Str("⠁ 2")
-Str("")
 Flush
 Up(3)
 Clear
@@ -1629,7 +1620,6 @@ Str("⠁ 1")
 Str("")
 NewLine
 Str("⠁ 2")
-Str("")
 Flush
 Up(3)
 Clear
@@ -1650,7 +1640,6 @@ Str("⠁ 1")
 Str("")
 NewLine
 Str("⠁ 2")
-Str("")
 Flush
 Up(3)
 Clear
@@ -1671,7 +1660,6 @@ Str("⠁ 1")
 Str("")
 NewLine
 Str("⠁ 2")
-Str("")
 Flush
 "#
     );
@@ -1709,7 +1697,6 @@ Str("⠁ 1")
 Str("")
 NewLine
 Str("⠁ 2")
-Str("")
 Flush
 "#
     );
@@ -1746,7 +1733,6 @@ Str("⠁ 1")
 Str("")
 NewLine
 Str("⠁ 2")
-Str("")
 Flush
 "#
     );
@@ -1778,7 +1764,6 @@ Str("⠁ 2")
 Str("")
 NewLine
 Str("⠁ 4")
-Str("")
 Flush
 Up(3)
 Clear


### PR DESCRIPTION
This is my attempt at fixing #447.

The code in `draw_to_term` is a bit of mess, with double definitions, complex branching, and I tried cleaning it up. I introduce a `LineType` enum to differentiate between text, bars and empty lines. The variables names have been renamed to reflect better what they represent. Some code has been shuffled around. Tests pass and I ran examples at random with no issues.

A sample program to understand what this PR wants to fix:
```rs
static LOREM_SMALL: &str = "Lorem ipsum dolor sit amet.";
static LOREM_BIG: &str= "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec nec viverra massa. Nunc nisl lectus,
auctor in lorem eu, maximus elementum est.";

fn generate_logs(manager: &indicatif::MultiProgress, i: u32) {
    if i % 20 == 0 {
        let _ = manager.println(LOREM_BIG);
    } else if i % 10 == 0 {
        let _ = manager.println(LOREM_SMALL);
    }
}

fn main() {
    let display_manager = indicatif::MultiProgress::new();
    let bar = display_manager.add(indicatif::ProgressBar::new(100));

    for i in 0..100 {
        generate_logs(&display_manager, i);
        std::thread::sleep(std::time::Duration::from_millis(10));
    }

    for i in 0..100 {
        bar.inc(1);
        generate_logs(&display_manager, i);
        std::thread::sleep(std::time::Duration::from_millis(100));
    }
}
```

This is the output of the above before the PR:
[![asciicast](https://asciinema.org/a/mwXUYBO3HC0wtYV4jLjjBVvNp.svg)](https://asciinema.org/a/mwXUYBO3HC0wtYV4jLjjBVvNp)