### PR TITLE
Replace `instant` with `web-time`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ futures = "0.3" # so the doctest for wrap_stream is nice
 pretty_assertions = "1.4.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-instant = "0.1"
+web-time = "1.1.0"
 
 [features]
 default = ["unicode-width", "console/unicode-width"]

--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -9,7 +9,7 @@ use std::time::Instant;
 
 use console::Term;
 #[cfg(target_arch = "wasm32")]
-use instant::Instant;
+use web_time::Instant;
 
 use crate::multi::{MultiProgressAlignment, MultiState};
 use crate::TermLike;

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -10,7 +10,7 @@ use crate::draw_target::{
 };
 use crate::progress_bar::ProgressBar;
 #[cfg(target_arch = "wasm32")]
-use instant::Instant;
+use web_time::Instant;
 
 /// Manages multiple progress bars from different threads
 #[derive(Debug, Clone)]

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -7,10 +7,10 @@ use std::time::Duration;
 use std::time::Instant;
 use std::{fmt, io, thread};
 
-#[cfg(target_arch = "wasm32")]
-use instant::Instant;
 #[cfg(test)]
 use once_cell::sync::Lazy;
+#[cfg(target_arch = "wasm32")]
+use web_time::Instant;
 
 use crate::draw_target::ProgressDrawTarget;
 use crate::state::{AtomicPosition, BarState, ProgressFinish, Reset, TabExpandedString};

--- a/src/state.rs
+++ b/src/state.rs
@@ -5,9 +5,9 @@ use std::time::Duration;
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
 
-#[cfg(target_arch = "wasm32")]
-use instant::Instant;
 use portable_atomic::{AtomicU64, AtomicU8, Ordering};
+#[cfg(target_arch = "wasm32")]
+use web_time::Instant;
 
 use crate::draw_target::ProgressDrawTarget;
 use crate::style::ProgressStyle;

--- a/src/style.rs
+++ b/src/style.rs
@@ -5,10 +5,10 @@ use std::mem;
 use std::time::Instant;
 
 use console::{measure_text_width, Style};
-#[cfg(target_arch = "wasm32")]
-use instant::Instant;
 #[cfg(feature = "unicode-segmentation")]
 use unicode_segmentation::UnicodeSegmentation;
+#[cfg(target_arch = "wasm32")]
+use web_time::Instant;
 
 use crate::format::{
     BinaryBytes, DecimalBytes, FormattedDuration, HumanBytes, HumanCount, HumanDuration,


### PR DESCRIPTION
Fixes https://github.com/console-rs/indicatif/issues/665. See: https://crates.io/crates/web-time.

Note that unlike `instant`, `web-time` falls back to `std::time` on non-WASM, so this kind of conditional exports are not really necessary:

```rust
#[cfg(not(target_arch = "wasm32"))]
use std::time::Instant;
#[cfg(target_arch = "wasm32")]
use web_time::Instant;
```

Instead, it could unconditionally be `web_time::Instant`, if making `web-time` a (really light, to be fair) dependency on non-WASM platforms as well is acceptable. I can update the PR accordingly, if desired.