### PR TITLE
Bump version to 0.17.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indicatif"
-version = "0.17.8"
+version = "0.17.9"
 edition = "2021"
 rust-version = "1.70"
 description = "A progress bar and cli reporting library for Rust"


### PR DESCRIPTION
The instant dependency will now cause audit issues for all downstream users, so let's get #666 and other accumulated improvements out soon.