### PR TITLE
Remove unnecessary spinner display in multi examples

### DIFF
--- a/examples/multi.rs
+++ b/examples/multi.rs
@@ -48,8 +48,6 @@ fn main() {
         let m = m.clone();
         let pb2 = pb2.clone();
         threads.push(thread::spawn(move || {
-            let spinner = m.add(ProgressBar::new_spinner().with_message(i.to_string()));
-            spinner.enable_steady_tick(Duration::from_millis(100));
             thread::sleep(
                 rand::thread_rng().gen_range(Duration::from_secs(1)..Duration::from_secs(5)),
             );

--- a/examples/multi.rs
+++ b/examples/multi.rs
@@ -45,7 +45,6 @@ fn main() {
             thread::sleep(Duration::from_secs(2));
         }
         pb.inc(1);
-        let m = m.clone();
         let pb2 = pb2.clone();
         threads.push(thread::spawn(move || {
             thread::sleep(


### PR DESCRIPTION
SSIA

|before|after|
|---|---|
|![before](https://github.com/user-attachments/assets/42ee63a3-eb62-4e52-a769-9e94f658962a)|![after](https://github.com/user-attachments/assets/6f83b969-c0a1-423a-9587-a4491b644c55)
