### PR TITLE
Only get draw_target-width when we actually draw

### DIFF
--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -351,6 +351,14 @@ impl Drawable<'_> {
             } => draw_state.draw_to_term(term_like, last_line_count),
         }
     }
+
+    pub(crate) fn width(&self) -> Option<u16> {
+        match self {
+            Self::Term { term, .. } => Some(term.size().1),
+            Self::Multi { state, .. } => state.width(),
+            Self::TermLike { term_like, .. } => Some(term_like.width()),
+        }
+    }
 }
 
 pub(crate) enum LineAdjust {

--- a/src/state.rs
+++ b/src/state.rs
@@ -183,8 +183,6 @@ impl BarState {
     }
 
     pub(crate) fn draw(&mut self, mut force_draw: bool, now: Instant) -> io::Result<()> {
-        let width = self.draw_target.width();
-
         // `|= self.is_finished()` should not be needed here, but we used to always draw for
         // finished progress bars, so it's kept as to not cause compatibility issues in weird cases.
         force_draw |= self.state.is_finished();
@@ -192,6 +190,9 @@ impl BarState {
             Some(drawable) => drawable,
             None => return Ok(()),
         };
+
+        // Getting the width can be expensive; thus this should happen after checking drawable.
+        let width = drawable.width();
 
         let mut draw_state = drawable.state();
 


### PR DESCRIPTION
When calling `BarState::draw`, there is a call to `self.draw_target.width()`.

However, that operation can be expensive and the width is not needed, if there is no draw-target.

Thus, this PR delays the calling `.width()` if there is not target to draw to.

For comparison, I've used this minibenchmark:

```rust
    let bar = ProgressBar::new_spinner();

    for n in 0..1_000_000 {
        bar.set_message(format!("{}", n));
    }
    bar.finish();
```

Using the latest release it runs in about 400ms, whilst the fixed version uses about 100ms.

The issue surfaced with uv, when resolving many packages: https://github.com/astral-sh/uv/issues/10384