### PR TITLE
Make `ProgressBar:set_tab_with` take `&self`

### DIFF
--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -161,7 +161,7 @@ impl ProgressBar {
     }
 
     /// Sets the tab width (default: 8). All tabs will be expanded to this many spaces.
-    pub fn set_tab_width(&mut self, tab_width: usize) {
+    pub fn set_tab_width(&self, tab_width: usize) {
         let mut state = self.state();
         state.set_tab_width(tab_width);
         state.draw(true, Instant::now()).unwrap();

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -737,7 +737,7 @@ fn basic_tab_expansion() {
     let mp =
         MultiProgress::with_draw_target(ProgressDrawTarget::term_like(Box::new(in_mem.clone())));
 
-    let mut spinner = mp.add(ProgressBar::new_spinner().with_message("Test\t:)"));
+    let spinner = mp.add(ProgressBar::new_spinner().with_message("Test\t:)"));
     spinner.tick();
 
     // 8 is the default number of spaces
@@ -753,7 +753,7 @@ fn tab_expansion_in_template() {
     let mp =
         MultiProgress::with_draw_target(ProgressDrawTarget::term_like(Box::new(in_mem.clone())));
 
-    let mut spinner = mp.add(
+    let spinner = mp.add(
         ProgressBar::new_spinner()
             .with_message("Test\t:)")
             .with_prefix("Pre\tfix!")


### PR DESCRIPTION
Currently, `ProgressBar:set_tab_with` is the only method that requires `&mut self`.

However, there is no reason that it needs exclusive access, and thus this can be just `&self`.