### PR TITLE
Add ProgressBar::force_draw

### DIFF
--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -409,7 +409,7 @@ impl ProgressBar {
         state.draw_target = target;
     }
 
-    /// Force a redraw of the progress bar to be in sync with its state.
+    /// Force a redraw of the progress bar to be in sync with its state
     ///
     /// For performance reasons the progress bar is not redrawn on each state update.
     /// This is normally not an issue, since new updates will eventually trigger rendering.

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -409,6 +409,17 @@ impl ProgressBar {
         state.draw_target = target;
     }
 
+    /// Force a redraw of the progress bar to be in sync with its state.
+    ///
+    /// For performance reasons the progress bar is not redrawn on each state update.
+    /// This is normally not an issue, since new updates will eventually trigger rendering.
+    ///
+    /// For slow running tasks it is recommended to rely on [`ProgressBar::enable_steady_tick()`]
+    /// to ensure continued rendering of the progress bar.
+    pub fn force_draw(&self) {
+        let _ = self.state().draw(true, Instant::now());
+    }
+
     /// Hide the progress bar temporarily, execute `f`, then redraw the progress bar
     ///
     /// Useful for external code that writes to the standard output.


### PR DESCRIPTION
Allow users to force a redraw of the progress bar.

This should normally not be needed, since there are more idiomatic ways to ensure that the progress bar is up to date.

Also, I've noticed that other ways to enforce redrawing (`.suspend()`) can lead to flickering, while `.force_draw()` does not.


Adresses: #688