### PR TITLE
Change `OnceCell` to `OnceLock` in `TabExpandedString`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indicatif"
-version = "0.17.10"
+version = "0.17.11"
 edition = "2021"
 rust-version = "1.70"
 description = "A progress bar and cli reporting library for Rust"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,3 +272,21 @@ pub use crate::rayon::ParallelProgressIterator;
 pub use crate::state::{ProgressFinish, ProgressState};
 pub use crate::style::ProgressStyle;
 pub use crate::term_like::TermLike;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[allow(dead_code)]
+    trait MustBeThreadSafe: Send + Sync {}
+
+    // Ensure that the following types are `Send + Sync`
+    impl MustBeThreadSafe for MultiProgress {}
+    impl MustBeThreadSafe for MultiProgressAlignment {}
+    impl MustBeThreadSafe for ProgressBar {}
+    impl MustBeThreadSafe for ProgressBarIter<()> {}
+    impl MustBeThreadSafe for ProgressFinish {}
+    impl MustBeThreadSafe for ProgressState {}
+    impl MustBeThreadSafe for ProgressStyle {}
+    impl MustBeThreadSafe for WeakProgressBar {}
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
-use std::cell::OnceCell;
 use std::io;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
@@ -355,7 +354,7 @@ pub(crate) enum TabExpandedString {
     NoTabs(Cow<'static, str>),
     WithTabs {
         original: Cow<'static, str>,
-        expanded: OnceCell<String>,
+        expanded: OnceLock<String>,
         tab_width: usize,
     },
 }
@@ -368,7 +367,7 @@ impl TabExpandedString {
             Self::WithTabs {
                 original: s,
                 tab_width,
-                expanded: OnceCell::new(),
+                expanded: OnceLock::new(),
             }
         }
     }


### PR DESCRIPTION
The change at [1] stores some data in a `OnceCell`, which made `ProgressStyle` no longer `Sync`. Fix this by changing the `OnceCell` to a `OnceLock`, and add a static test that all relevant public types are `Send` and `Sync`.

[1]: https://github.com/console-rs/indicatif/pull/684