### PR TITLE
Use width to truncate `HumanFloatCount` values

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -373,6 +373,9 @@ mod tests {
         assert_eq!("1,234.1", format!("{:.1}", HumanFloatCount(1234.1234321)));
         assert_eq!("1,234.12", format!("{:.2}", HumanFloatCount(1234.1234321)));
         assert_eq!("1,234.123", format!("{:.3}", HumanFloatCount(1234.1234321)));
-        assert_eq!("1,234.1234320999999454215867445", format!("{:.25}", HumanFloatCount(1234.1234321)));
+        assert_eq!(
+            "1,234.1234320999999454215867445",
+            format!("{:.25}", HumanFloatCount(1234.1234321))
+        );
     }
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -187,7 +187,10 @@ impl fmt::Display for HumanFloatCount {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use fmt::Write;
 
-        let num = format!("{:.4}", self.0);
+        // Use formatter's precision if provided, otherwise default to 4
+        let precision = f.precision().unwrap_or(4);
+        let num = format!("{:.*}", precision, self.0);
+
         let (int_part, frac_part) = match num.split_once('.') {
             Some((int_str, fract_str)) => (int_str.to_string(), fract_str),
             None => (self.0.trunc().to_string(), ""),
@@ -366,5 +369,10 @@ mod tests {
             "1,234,567,890.1234",
             format!("{}", HumanFloatCount(1234567890.1234321))
         );
+        assert_eq!("1,234", format!("{:.0}", HumanFloatCount(1234.1234321)));
+        assert_eq!("1,234.1", format!("{:.1}", HumanFloatCount(1234.1234321)));
+        assert_eq!("1,234.12", format!("{:.2}", HumanFloatCount(1234.1234321)));
+        assert_eq!("1,234.123", format!("{:.3}", HumanFloatCount(1234.1234321)));
+        assert_eq!("1,234.1234320999999454215867445", format!("{:.25}", HumanFloatCount(1234.1234321)));
     }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -308,9 +308,22 @@ impl ProgressStyle {
                             "elapsed" => buf
                                 .write_fmt(format_args!("{:#}", HumanDuration(state.elapsed())))
                                 .unwrap(),
-                            "per_sec" => buf
-                                .write_fmt(format_args!("{}/s", HumanFloatCount(state.per_sec())))
-                                .unwrap(),
+                            "per_sec" => {
+                                if let Some(width) = width {
+                                    buf.write_fmt(format_args!(
+                                        "{:.1$}/s",
+                                        HumanFloatCount(state.per_sec()),
+                                        *width as usize
+                                    ))
+                                    .unwrap();
+                                } else {
+                                    buf.write_fmt(format_args!(
+                                        "{}/s",
+                                        HumanFloatCount(state.per_sec())
+                                    ))
+                                    .unwrap();
+                                }
+                            }
                             "bytes_per_sec" => buf
                                 .write_fmt(format_args!("{}/s", HumanBytes(state.per_sec() as u64)))
                                 .unwrap(),


### PR DESCRIPTION
- Use `width` to truncate `HumanFloatCount` values 
  - Normally float truncation is done by using `.#`, but in `indicatif` `.` is reserved for specifying a style string.
  - Resolves #485 and #663

Examples:

`"{spinner:.green} [{elapsed}] [{bar:.blue}] {human_pos}/{human_len} ({per_sec:0}, ETA: {eta})"`:

<img width="456" alt="image" src="https://github.com/user-attachments/assets/14a4b42f-d767-4fe9-a5dc-3636dcde9e9e" />

`"{spinner:.green} [{elapsed}] [{bar:.blue}] {human_pos}/{human_len} ({per_sec:4}, ETA: {eta})"`:

<img width="487" alt="image" src="https://github.com/user-attachments/assets/b48346bd-5d66-466a-85b2-b2211c26a05a" />

