### PR TITLE
`ProgressStyle` enable/disable colors based on draw target

### DIFF
--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
 
-use console::Term;
+use console::{Term, TermTarget};
 #[cfg(target_arch = "wasm32")]
 use web_time::Instant;
 
@@ -125,6 +125,16 @@ impl ProgressDrawTarget {
             TargetKind::Term { ref term, .. } => !term.is_term(),
             TargetKind::Multi { ref state, .. } => state.read().unwrap().is_hidden(),
             _ => false,
+        }
+    }
+
+    /// This is used in progress bars to determine whether to use stdout or stderr
+    /// for detecting color support.
+    pub(crate) fn is_stderr(&self) -> bool {
+        if let TargetKind::Term { ref term, .. } = self.kind {
+            matches!(term.target(), TermTarget::Stderr)
+        } else {
+            false
         }
     }
 

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -157,6 +157,11 @@ impl ProgressBar {
     ///
     /// This does not redraw the bar. Call [`ProgressBar::tick()`] to force it.
     pub fn set_style(&self, style: ProgressStyle) {
+        let style = if self.state().draw_target.is_stderr() {
+            style.for_stderr()
+        } else {
+            style
+        };
         self.state().set_style(style);
     }
 


### PR DESCRIPTION
Resolves #698 

A `ProgressBar` using stderr as the draw target will now implicitly use stderr to determine if colors are enabled (by configuring its `ProgressStyle`).

Previously, this was not configured, so the default behavior was to detect colors using stdout no matter what.
