### PR TITLE
Patch to include unit-prefix for attribution

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ readme = "README.md"
 exclude = ["screenshots/*"]
 
 [dependencies]
-console = { version = "0.15", default-features = false, features = ["ansi-parsing"] }
+console = { version = "0.15", default-features = false, features = [
+    "ansi-parsing",
+] }
 futures-core = { version = "0.3", default-features = false, optional = true }
 number_prefix = "0.4"
 portable-atomic = "1.0.0"
@@ -23,12 +25,15 @@ unicode-segmentation = { version = "1", optional = true }
 unicode-width = { version = "0.2", optional = true }
 vt100 = { version = "0.15.1", optional = true }
 
+[patch.crates-io]
+number_prefix = { version = "0.5.1", package = "unit-prefix", git = 'https://github.com/commons-rs/unit-prefix' }
+
 [dev-dependencies]
 clap = { version = "4", features = ["color", "derive"] }
 once_cell = "1"
 rand = "0.9"
 tokio = { version = "1", features = ["fs", "time", "rt"] }
-futures = "0.3" # so the doctest for wrap_stream is nice
+futures = "0.3"                                            # so the doctest for wrap_stream is nice
 pretty_assertions = "1.4.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -36,7 +41,11 @@ web-time = "1.1.0"
 
 [features]
 default = ["unicode-width", "console/unicode-width"]
-improved_unicode = ["unicode-segmentation", "unicode-width", "console/unicode-width"]
+improved_unicode = [
+    "unicode-segmentation",
+    "unicode-width",
+    "console/unicode-width",
+]
 in_memory = ["vt100"]
 futures = ["dep:futures-core"]
 


### PR DESCRIPTION
number-prefix is unmaintained and does not include license information within its crate.  This PR patches number_prefix to use the maintained fork.

See: https://github.com/ogham/rust-number-prefix/pull/8