### PR TITLE
[style] Improve integer completion percentage calculation for accurate representation (358/359 is NOT 100%)

### DIFF
--- a/src/style.rs
+++ b/src/style.rs
@@ -1055,4 +1055,21 @@ mod tests {
         assert_eq!(&buf[2], "bar");
         assert_eq!(&buf[3], "baz");
     }
+
+    #[test]
+    fn test_pct_precision() {
+        // seeing something that's not finished as 100% hurts my eyes
+        const WIDTH: u16 = 80;
+        let pos = Arc::new(AtomicPosition::new());
+        pos.set(358);
+        let state = ProgressState::new(Some(359), pos);
+
+        let style = ProgressStyle::default_bar()
+                .template(
+                    &format!("{{pos}}/{{len}} {{percent}}%"),
+                ).unwrap();
+        let mut buf = Vec::new();
+        style.format_state(&state, &mut buf, WIDTH);
+        assert_eq!(&buf[0], "358/359 100%");
+    }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -302,7 +302,7 @@ impl ProgressStyle {
                                 buf.write_fmt(format_args!("{}", HumanCount(len))).unwrap();
                             }
                             "percent" => buf
-                                .write_fmt(format_args!("{:.*}", 0, state.fraction() * 100f32))
+                                .write_fmt(format_args!("{:.*}", 0, (state.fraction() * 100f32).floor()))
                                 .unwrap(),
                             "percent_precise" => buf
                                 .write_fmt(format_args!("{:.*}", 3, state.fraction() * 100f32))
@@ -1062,7 +1062,7 @@ mod tests {
         const WIDTH: u16 = 80;
         let pos = Arc::new(AtomicPosition::new());
         pos.set(358);
-        let state = ProgressState::new(Some(359), pos);
+        let state = ProgressState::new(Some(359), pos.clone());
 
         let style = ProgressStyle::default_bar()
                 .template(
@@ -1070,6 +1070,10 @@ mod tests {
                 ).unwrap();
         let mut buf = Vec::new();
         style.format_state(&state, &mut buf, WIDTH);
-        assert_eq!(&buf[0], "358/359 100%");
+        assert_eq!(&buf[0], "358/359 99%");
+        buf.clear();
+        pos.set(359);
+        style.format_state(&state, &mut buf, WIDTH);
+        assert_eq!(&buf[0], "359/359 100%");
     }
 }


### PR DESCRIPTION
By default rust float formatting doesn't round down - in fact they use
round_ties_even udner the hood: https://doc.rust-lang.org/std/primitive.f32.html#method.round_ties_even

For percentage calculations this is not great - in particular we shouldn't show 100% when the operation is not fully complete.

