### PR TITLE
Switch dep number_prefix to unit_prefix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["screenshots/*"]
 [dependencies]
 console = { version = "0.15", default-features = false, features = ["ansi-parsing"] }
 futures-core = { version = "0.3", default-features = false, optional = true }
-number_prefix = "0.4"
+unit-prefix = "0.5.1"
 portable-atomic = "1.0.0"
 rayon = { version = "1.1", optional = true }
 tokio = { version = "1", optional = true, features = ["io-util"] }

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::time::Duration;
 
-use number_prefix::NumberPrefix;
+use unit_prefix::NumberPrefix;
 
 const SECOND: Duration = Duration::from_secs(1);
 const MINUTE: Duration = Duration::from_secs(60);


### PR DESCRIPTION
number_prefix is unmaintained and doesn't provide for attribution, whereas unit_prefix does both.