### PR TITLE
Bump version to 0.18.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indicatif"
-version = "0.17.12"
+version = "0.18.0"
 edition = "2021"
 rust-version = "1.70"
 description = "A progress bar and cli reporting library for Rust"


### PR DESCRIPTION
Because types from the console crate appear in our public API, #712 was actually a semver-incompatible change. I've yanked the 0.17.12 release, and we should republish as 0.18.0.