### PR TITLE
Make ProgressBar::index public

### DIFF
--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -619,7 +619,7 @@ impl ProgressBar {
     }
 
     /// Index in the `MultiState`
-    pub(crate) fn index(&self) -> Option<usize> {
+    pub fn index(&self) -> Option<usize> {
         self.state().draw_target.remote().map(|(_, idx)| idx)
     }
 


### PR DESCRIPTION
This could be useful for some user crates, for example potentially can help solve the issue with order of child progress bars that exists in this crate - https://github.com/emersonford/tracing-indicatif/blob/main/src/pb_manager.rs#L217-L221