### PR TITLE
Fix semver breaking dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ exclude = ["screenshots/*"]
 
 [dependencies]
 regex = { version = "1.3.1", default-features = false, features = ["std"] }
-lazy_static = "1.0"
+lazy_static = "1.1"
 number_prefix = "0.4"
-console = { version = ">=0.9.1, <1.0.0", default-features = false }
+console = { version = ">=0.9.1, <0.16", default-features = false }
 unicode-segmentation = { version = "1.6.0", optional = true }
 unicode-width = { version = "0.1.7", optional = true }
 rayon = { version = "1.0", optional = true }


### PR DESCRIPTION
The dependency versions for lazy-static and console were too loosely specified, leading to build fails for some lock files. This PR updates lazy-static version from 1.0 to 1.1 and bounds console below 0.16 to avoid those issues.