### PR TITLE
Fix wide_bar width computation with a multiline message

### DIFF
--- a/src/style.rs
+++ b/src/style.rs
@@ -463,7 +463,11 @@ impl WideElement<'_> {
         buf: &mut String,
         width: u16,
     ) -> String {
-        let left = (width as usize).saturating_sub(measure_text_width(&cur.replace('\x00', "")));
+        let left =
+            (width as usize).saturating_sub(match cur.lines().find(|line| line.contains('\x00')) {
+                Some(line) => measure_text_width(&line.replace('\x00', "")),
+                None => measure_text_width(&cur),
+            });
         match self {
             Self::Bar { alt_style } => cur.replace(
                 '\x00',


### PR DESCRIPTION
Before this PR, the whole width of the message was used to compute the bar width, making the bar very small or invisible.
In practice, only the first line of the message should have an impact on the bar width.