### PR TITLE
Fix duration after finish

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -842,7 +842,7 @@ mod tests {
         );
     }
 
-    fn state_started_at(start_at: Instant) -> BarState {
+    fn state_started_at(started: Instant) -> BarState {
         BarState {
             draw_target: ProgressDrawTarget::hidden(),
             on_finish: ProgressFinish::default(),
@@ -853,8 +853,8 @@ mod tests {
                     len: None,
                     tick: 0,
                     status: Status::InProgress,
-                    started: start_at,
-                    est: Estimator::new(start_at),
+                    started,
+                    est: Estimator::new(started),
                     message: TabExpandedString::NoTabs("".into()),
                     prefix: TabExpandedString::NoTabs("".into()),
                 }


### PR DESCRIPTION
When initializing progress bar with style that exposes template variable `{duration}`, the duration is set to 0 after progress bar finishes.

This is is unexpected and makes progress bar styles other than 'ProgressFinish::AndClear' display wrong duration.

This will add Duration parameter to `crate::state::State::Done*` variants and uses it to display duration if curret state of the progress bar is one of the Done states.

Fixes #557