### PR TITLE
Expose the current tab width

### DIFF
--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -628,6 +628,11 @@ impl ProgressBar {
         self.state().state.elapsed()
     }
 
+    /// Returns the current tab width
+    pub fn tab_width(&self) -> usize {
+        self.state().tab_width
+    }
+
     /// Index in the `MultiState`
     pub(crate) fn index(&self) -> Option<usize> {
         self.state().draw_target.remote().map(|(_, idx)| idx)


### PR DESCRIPTION
I'm developing a build workflow for my project, which includes several components that each spawn multiple sub-tasks. I want to increase the tab width to represent the depth of each task:

```rust
fn new_sub_task (parent: &ProgressBar) {
  let child = ProgressBar::new(0).set_tab_width(parent.tab_width() + 2);

  /* ... */
}
```