### PR TITLE
fix: respect NO_COLOR and TERM=dumb environment variables

### DIFF
--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -69,8 +69,13 @@ impl ProgressDrawTarget {
     /// hidden.  This is done so that piping to a file will not produce
     /// useless escape codes in that file.
     ///
+    /// Progress bars will also be hidden if `NO_COLOR` is set or `TERM` is unset/`dumb`.
+    ///
     /// Will panic if `refresh_rate` is `0`.
     pub fn term(term: Term, refresh_rate: u8) -> Self {
+        if !term.features().colors_supported() {
+            return Self::hidden();
+        }
         Self {
             kind: TargetKind::Term {
                 term,
@@ -178,10 +183,6 @@ impl ProgressDrawTarget {
                 rate_limiter,
                 draw_state,
             } => {
-                if !term.is_term() {
-                    return None;
-                }
-
                 match force_draw || rate_limiter.allow(now) {
                     true => Some(Drawable::Term {
                         term,


### PR DESCRIPTION
Fixes #763

Changes `is_hidden()` and `drawable()` to check `term.features().colors_supported()` instead of `term.is_term()`. The `console` crate's `colors_supported()` already checks for `NO_COLOR` and `TERM=dumb`, so this change makes indicatif respect those signals.

## Test plan

Use the MRE from #763 with a path dependency:
```toml
indicatif = { path = "path/to/fix/branch/indicatif" }
```

`script` creates a pseudo-TTY so `isatty()` returns true. Grepping for `1b 5b` (hex `ESC[`) detects ANSI escape sequences. With the fix, no output should appear when `TERM=dumb` or `NO_COLOR=1`.

```console
# Normal TTY - escape sequences expected
script -q /dev/null ./target/release/mre 2>&1 | xxd | grep '1b 5b'
# Output: 00000050: ... 0d1b 5b32 4b ...  (ESC[2K present)

# With TERM=dumb - escape sequences should be suppressed
TERM=dumb script -q /dev/null ./target/release/mre 2>&1 | xxd | grep '1b 5b'
# No output expected

# With NO_COLOR=1 - escape sequences should be suppressed
NO_COLOR=1 script -q /dev/null ./target/release/mre 2>&1 | xxd | grep '1b 5b'
# No output expected
```
