### PR TITLE
Add `ProgressBar::visual_index` and clarify meaning of `ProgressBar::index`.

### DIFF
--- a/src/multi.rs
+++ b/src/multi.rs
@@ -558,9 +558,28 @@ mod tests {
         let p1 = mp.add(ProgressBar::new(1));
         let p2 = mp.add(ProgressBar::new(1));
         let p3 = mp.add(ProgressBar::new(1));
+
+        // Check position of bars on screen
+        assert_eq!(
+            &[
+                p0.visual_index().unwrap(),
+                p1.visual_index().unwrap(),
+                p2.visual_index().unwrap(),
+                p3.visual_index().unwrap()
+            ],
+            &[0, 1, 2, 3]
+        );
+
         mp.remove(&p2);
         mp.remove(&p1);
+
+        assert_eq!(
+            &[p0.visual_index().unwrap(), p3.visual_index().unwrap()],
+            &[0, 1]
+        );
+
         let p4 = mp.insert(1, ProgressBar::new(1));
+        assert_eq!(p4.visual_index().unwrap(), 1);
 
         let state = mp.state.read().unwrap();
         // the removed place for p1 is reused
@@ -586,6 +605,18 @@ mod tests {
         assert_eq!(p1.index(), None);
         assert_eq!(p2.index(), None);
         assert_eq!(p3.index().unwrap(), 3);
+
+        // Check position of bars on screen
+        assert_eq!(
+            &[
+                p0.visual_index(),
+                p1.visual_index(),
+                p2.visual_index(),
+                p3.visual_index(),
+                p4.visual_index()
+            ],
+            &[Some(0), None, None, Some(2), Some(1)]
+        );
     }
 
     #[test]
@@ -604,6 +635,18 @@ mod tests {
         assert_eq!(p2.index().unwrap(), 2);
         assert_eq!(p3.index().unwrap(), 3);
         assert_eq!(p4.index().unwrap(), 4);
+
+        // Check position of bars on screen
+        assert_eq!(
+            &[
+                p0.visual_index().unwrap(),
+                p1.visual_index().unwrap(),
+                p2.visual_index().unwrap(),
+                p3.visual_index().unwrap(),
+                p4.visual_index().unwrap()
+            ],
+            &[1, 2, 4, 3, 0]
+        );
     }
 
     #[test]
@@ -622,6 +665,18 @@ mod tests {
         assert_eq!(p2.index().unwrap(), 2);
         assert_eq!(p3.index().unwrap(), 3);
         assert_eq!(p4.index().unwrap(), 4);
+
+        // Check position of bars on screen
+        assert_eq!(
+            &[
+                p0.visual_index().unwrap(),
+                p1.visual_index().unwrap(),
+                p2.visual_index().unwrap(),
+                p3.visual_index().unwrap(),
+                p4.visual_index().unwrap()
+            ],
+            &[0, 2, 3, 4, 1]
+        );
     }
 
     #[test]
@@ -640,6 +695,18 @@ mod tests {
         assert_eq!(p2.index().unwrap(), 2);
         assert_eq!(p3.index().unwrap(), 3);
         assert_eq!(p4.index().unwrap(), 4);
+
+        // Check position of bars on screen
+        assert_eq!(
+            &[
+                p0.visual_index().unwrap(),
+                p1.visual_index().unwrap(),
+                p2.visual_index().unwrap(),
+                p3.visual_index().unwrap(),
+                p4.visual_index().unwrap()
+            ],
+            &[1, 2, 4, 0, 3]
+        );
     }
 
     #[test]
@@ -662,6 +729,20 @@ mod tests {
         assert_eq!(p4.index().unwrap(), 4);
         assert_eq!(p5.index().unwrap(), 5);
         assert_eq!(p6.index().unwrap(), 6);
+
+        // Check position of bars on screen
+        assert_eq!(
+            &[
+                p0.visual_index().unwrap(),
+                p1.visual_index().unwrap(),
+                p2.visual_index().unwrap(),
+                p3.visual_index().unwrap(),
+                p4.visual_index().unwrap(),
+                p5.visual_index().unwrap(),
+                p6.visual_index().unwrap()
+            ],
+            &[3, 5, 6, 0, 2, 1, 4]
+        );
     }
 
     #[test]

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -416,12 +416,10 @@ impl MultiState {
                 self.ordering.insert(pos, idx);
             }
             InsertLocation::After(after_idx) => {
-                let pos = self.ordering.iter().position(|i| *i == after_idx).unwrap();
-                self.ordering.insert(pos + 1, idx);
+                self.ordering.insert(self.visual_index(after_idx) + 1, idx);
             }
             InsertLocation::Before(before_idx) => {
-                let pos = self.ordering.iter().position(|i| *i == before_idx).unwrap();
-                self.ordering.insert(pos, idx);
+                self.ordering.insert(self.visual_index(before_idx), idx);
             }
         }
 
@@ -464,6 +462,14 @@ impl MultiState {
 
     fn len(&self) -> usize {
         self.members.len() - self.free_set.len()
+    }
+
+    /// Map from opaque index to position on screen.
+    pub(crate) fn visual_index(&self, opaque_index: usize) -> usize {
+        self.ordering
+            .iter()
+            .position(|v| *v == opaque_index)
+            .expect("no such member")
     }
 }
 

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -633,7 +633,13 @@ impl ProgressBar {
         self.state().tab_width
     }
 
-    /// Index in the `MultiState`
+    /// Opaque index in the `MultiState`
+    ///
+    /// This value is an implementation detail and does not necessarily correspond to visual
+    /// position on the screen.
+    ///
+    /// It is an index into `MultiState::members`, which is not in any particular order (due to
+    /// reclaiming of indices from the `MultiState::free_set`).
     pub(crate) fn index(&self) -> Option<usize> {
         self.state().draw_target.remote().map(|(_, idx)| idx)
     }

--- a/src/progress_bar.rs
+++ b/src/progress_bar.rs
@@ -644,6 +644,15 @@ impl ProgressBar {
         self.state().draw_target.remote().map(|(_, idx)| idx)
     }
 
+    /// If this [`ProgressBar`] is a member of a [`MultiProgress`](crate::MultiProgress), then return visual position
+    /// on screen. Otherwise, `None`.
+    pub fn visual_index(&self) -> Option<usize> {
+        self.state()
+            .draw_target
+            .remote()
+            .map(|(remote, idx)| remote.read().unwrap().visual_index(idx))
+    }
+
     /// Current message
     pub fn message(&self) -> String {
         self.state().state.message.expanded().to_string()


### PR DESCRIPTION
`MultiProgress::insert` lets users insert a progress bar at a specified position within the `MultiProgress`. Before this PR, there was no way (besides keeping track manually) to know the position within the `MultiProgress` of a `ProgressBar`.

The `ProgressBar::index` method would be tempting if `pub`, but not appropriate because it refers to the opaque index within the `MultiState`'s data structures. This PR also clarifies its documentation.

Something else that this PR enables is that users can now write their own `insert_after_with_offset` (as suggested in https://github.com/console-rs/indicatif/pull/724#issuecomment-3145629928), i.e. `mp.insert(other_pb.visual_index() + offset, pb)`



Supersedes #782 and #724
