### PR TITLE
Upgrade rand to 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,9 +499,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom",


### PR DESCRIPTION
Should address https://rustsec.org/advisories/RUSTSEC-2026-0097