### PR TITLE
Use `div_duration_f64`

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -116,8 +116,7 @@ impl fmt::Display for HumanDuration {
         }
 
         let (unit, name, alt) = UNITS[idx];
-        // FIXME when `div_duration_f64` is stable
-        let mut t = (self.0.as_secs_f64() / unit.as_secs_f64()).round() as usize;
+        let mut t = self.0.div_duration_f64(unit).round() as usize;
         if idx < UNITS.len() - 1 {
             t = Ord::max(t, 2);
         }


### PR DESCRIPTION
[`div_duration_f64`](https://doc.rust-lang.org/stable/std/time/struct.Duration.html#method.div_duration_f64) has been stable since 1.80.0 and our MSRV is 1.85.