### PR TITLE
fix: correctly detect dumb terminal on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indicatif"
-version = "0.18.5"
+version = "0.18.6"
 dependencies = [
  "clap",
  "console",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,9 +135,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indicatif"
-version = "0.18.5"
+version = "0.18.6"
 edition = "2021"
 rust-version = "1.85"
 description = "A progress bar and cli reporting library for Rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 exclude = ["screenshots/*"]
 
 [dependencies]
-console = { version = "0.16", default-features = false, features = ["ansi-parsing", "std"] }
+console = { version = "0.16.4", default-features = false, features = ["ansi-parsing", "std"] }
 futures-core = { version = "0.3", default-features = false, optional = true }
 unit-prefix = "0.5.1"
 portable-atomic = "1.12.0"

--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -1,3 +1,4 @@
+use std::io;
 use std::ops::{Add, AddAssign, Sub};
 use std::slice::SliceIndex;
 use std::sync::{Arc, RwLock, RwLockWriteGuard};
@@ -5,11 +6,10 @@ use std::thread::panicking;
 use std::time::Duration;
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
-use std::{env, io};
 
 #[cfg(feature = "unicode-width")]
 use console::AnsiCodeIterator;
-use console::{Term, TermTarget};
+use console::{is_dumb, Term, TermTarget};
 #[cfg(feature = "unicode-width")]
 use unicode_width::UnicodeWidthChar;
 #[cfg(all(target_arch = "wasm32", feature = "wasmbind"))]
@@ -77,12 +77,7 @@ impl ProgressDrawTarget {
     ///
     /// Will panic if `refresh_rate` is `0`.
     pub fn term(term: Term, refresh_rate: u8) -> Self {
-        let term_is_dumb_or_unset = match env::var("TERM") {
-            Ok(term) => term == "dumb",
-            Err(_) => true,
-        };
-
-        if !term.is_term() || term_is_dumb_or_unset {
+        if !term.is_term() || is_dumb() {
             return Self::hidden();
         }
         Self {


### PR DESCRIPTION
# Fix incorrect dumb-terminal detection on Windows

The current check for whether to hide the progress bar relies on reading the TERM environment variable directly:
```rs
let term_is_dumb_or_unset = match env::var("TERM") {
    Ok(term) => term == "dumb",
    Err(_) => true,
};
```

This treats an unset `TERM` as "dumb" and hides the progress bar.

On Windows, `TERM` is typically not set at all, even in perfectly capable terminals (Windows Terminal, PowerShell, cmd.exe, etc.), so this logic incorrectly hides progress bars on Windows in cases where they should be shown.

## Behavior

Unset `TERM` environment variable is now treated as "not dumb" on Windows.

## Note

This depends on `is_dumb()` being exposed from the console crate. See console-rs/console#290 for the corresponding change adding a public `is_dumb()` function.

- console-rs/console#290
- #808 