### PR TITLE
Fix SGR attribute bleed from filled bar style into empty segment (#727)

### DIFF
--- a/src/style.rs
+++ b/src/style.rs
@@ -209,14 +209,7 @@ impl ProgressStyle {
             num: bg,
         };
 
-        // Style the filled and empty segments independently, so each emits its
-        // own reset. Wrapping the whole bar in the filled style with the empty
-        // style nested inside leaks cumulative SGR attributes (bold, dim, blink,
-        // underline, reverse) from the filled style into the empty segment: the
-        // empty style's codes override colors but attributes keep accumulating
-        // until the single outer reset (see #727). When no explicit empty style
-        // is given, fall back to the filled style so single-color bars keep
-        // coloring the empty segment as before.
+        // Each segment is styled on its own so it emits its own reset.
         BarDisplay {
             filled: style.unwrap_or(&Style::new()).apply_to(FilledDisplay {
                 chars: &self.progress_chars,
@@ -359,11 +352,7 @@ impl ProgressStyle {
                         }
                     };
 
-                    // Bar placeholders style their filled/empty segments
-                    // internally (see `format_bar`), so the generic outer
-                    // style-wrap must be skipped for them: wrapping the whole bar
-                    // in the filled style is exactly what leaks attributes into
-                    // the empty segment (see #727).
+                    // `format_bar` styles the bar's segments itself.
                     let style = match key.as_str() {
                         "bar" | "wide_bar" => None,
                         _ => style.as_ref(),
@@ -714,9 +703,7 @@ impl fmt::Display for BarDisplay<'_> {
     }
 }
 
-/// The filled portion of a progress bar: the fully-filled clusters followed by
-/// the optional "current" (partially-filled) cluster. Styled independently from
-/// the empty portion so it emits its own reset (see #727).
+/// The filled clusters of a progress bar, plus the partially-filled one.
 struct FilledDisplay<'a> {
     chars: &'a [Box<str>],
     filled: usize,
@@ -1163,11 +1150,7 @@ mod tests {
         );
     }
 
-    // Regression test for #727: a cumulative SGR attribute on the filled style
-    // (here `blink`, `\x1b[5m`) must not leak into the empty segment. Because the
-    // filled and empty segments are now styled independently, each emits its own
-    // reset, so blink is cleared by the reset after `====>` rather than persisting
-    // across the empty `---` until a single trailing reset.
+    // #727: blink on the filled style must not carry into the empty segment.
     #[test]
     fn bar_style_does_not_bleed_attributes_into_empty() {
         set_colors_enabled(true);

--- a/src/style.rs
+++ b/src/style.rs
@@ -168,7 +168,13 @@ impl ProgressStyle {
         &self.tick_strings[self.tick_strings.len() - 1]
     }
 
-    fn format_bar(&self, fract: f32, width: usize, alt_style: Option<&Style>) -> BarDisplay<'_> {
+    fn format_bar(
+        &self,
+        fract: f32,
+        width: usize,
+        style: Option<&Style>,
+        alt_style: Option<&Style>,
+    ) -> BarDisplay<'_> {
         // The number of clusters from progress_chars to write (rounding down).
         let width = width / self.char_width;
         // The number of full clusters (including a fractional component for a partially-full one).
@@ -203,11 +209,21 @@ impl ProgressStyle {
             num: bg,
         };
 
+        // Style the filled and empty segments independently, so each emits its
+        // own reset. Wrapping the whole bar in the filled style with the empty
+        // style nested inside leaks cumulative SGR attributes (bold, dim, blink,
+        // underline, reverse) from the filled style into the empty segment: the
+        // empty style's codes override colors but attributes keep accumulating
+        // until the single outer reset (see #727). When no explicit empty style
+        // is given, fall back to the filled style so single-color bars keep
+        // coloring the empty segment as before.
         BarDisplay {
-            chars: &self.progress_chars,
-            filled: entirely_filled,
-            cur,
-            rest: alt_style.unwrap_or(&Style::new()).apply_to(rest),
+            filled: style.unwrap_or(&Style::new()).apply_to(FilledDisplay {
+                chars: &self.progress_chars,
+                filled: entirely_filled,
+                cur,
+            }),
+            rest: alt_style.or(style).unwrap_or(&Style::new()).apply_to(rest),
         }
     }
 
@@ -239,7 +255,7 @@ impl ProgressStyle {
                     } else {
                         match key.as_str() {
                             "wide_bar" => {
-                                wide = Some(WideElement::Bar { alt_style });
+                                wide = Some(WideElement::Bar { style, alt_style });
                                 buf.push('\x00');
                             }
                             "bar" => buf
@@ -248,6 +264,7 @@ impl ProgressStyle {
                                     self.format_bar(
                                         state.fraction(),
                                         width.unwrap_or(20) as usize,
+                                        style.as_ref(),
                                         alt_style.as_ref(),
                                     )
                                 ))
@@ -342,6 +359,16 @@ impl ProgressStyle {
                         }
                     };
 
+                    // Bar placeholders style their filled/empty segments
+                    // internally (see `format_bar`), so the generic outer
+                    // style-wrap must be skipped for them: wrapping the whole bar
+                    // in the filled style is exactly what leaks attributes into
+                    // the empty segment (see #727).
+                    let style = match key.as_str() {
+                        "bar" | "wide_bar" => None,
+                        _ => style.as_ref(),
+                    };
+
                     match width {
                         Some(width) => {
                             let padded = PaddedStringDisplay {
@@ -416,8 +443,13 @@ impl Write for TabRewriter<'_> {
 
 #[derive(Clone, Copy)]
 enum WideElement<'a> {
-    Bar { alt_style: &'a Option<Style> },
-    Message { align: &'a Alignment },
+    Bar {
+        style: &'a Option<Style>,
+        alt_style: &'a Option<Style>,
+    },
+    Message {
+        align: &'a Alignment,
+    },
 }
 
 impl WideElement<'_> {
@@ -435,11 +467,19 @@ impl WideElement<'_> {
                 None => measure_text_width(&cur),
             });
         match self {
-            Self::Bar { alt_style } => cur.replace(
+            Self::Bar {
+                style: bar_style,
+                alt_style,
+            } => cur.replace(
                 '\x00',
                 &format!(
                     "{}",
-                    style.format_bar(state.fraction(), left, alt_style.as_ref())
+                    style.format_bar(
+                        state.fraction(),
+                        left,
+                        bar_style.as_ref(),
+                        alt_style.as_ref(),
+                    )
                 ),
             ),
             WideElement::Message { align } => {
@@ -663,13 +703,27 @@ enum State {
 }
 
 struct BarDisplay<'a> {
-    chars: &'a [Box<str>],
-    filled: usize,
-    cur: Option<usize>,
+    filled: console::StyledObject<FilledDisplay<'a>>,
     rest: console::StyledObject<RepeatedStringDisplay<'a>>,
 }
 
 impl fmt::Display for BarDisplay<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.filled.fmt(f)?;
+        self.rest.fmt(f)
+    }
+}
+
+/// The filled portion of a progress bar: the fully-filled clusters followed by
+/// the optional "current" (partially-filled) cluster. Styled independently from
+/// the empty portion so it emits its own reset (see #727).
+struct FilledDisplay<'a> {
+    chars: &'a [Box<str>],
+    filled: usize,
+    cur: Option<usize>,
+}
+
+impl fmt::Display for FilledDisplay<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for _ in 0..self.filled {
             f.write_str(&self.chars[0])?;
@@ -677,7 +731,7 @@ impl fmt::Display for BarDisplay<'_> {
         if let Some(cur) = self.cur {
             f.write_str(&self.chars[cur])?;
         }
-        self.rest.fmt(f)
+        Ok(())
     }
 }
 
@@ -1105,7 +1159,34 @@ mod tests {
         style.format_state(&state, &mut buf, WIDTH);
         assert_eq!(
             &buf[0],
-            "\u{1b}[31m\u{1b}[44m====\u{1b}[32m\u{1b}[46m----\u{1b}[0m\u{1b}[0m"
+            "\u{1b}[31m\u{1b}[44m====\u{1b}[0m\u{1b}[32m\u{1b}[46m----\u{1b}[0m"
+        );
+    }
+
+    // Regression test for #727: a cumulative SGR attribute on the filled style
+    // (here `blink`, `\x1b[5m`) must not leak into the empty segment. Because the
+    // filled and empty segments are now styled independently, each emits its own
+    // reset, so blink is cleared by the reset after `====>` rather than persisting
+    // across the empty `---` until a single trailing reset.
+    #[test]
+    fn bar_style_does_not_bleed_attributes_into_empty() {
+        set_colors_enabled(true);
+
+        const CHARS: &str = "=>-";
+        const WIDTH: u16 = 8;
+        let pos = Arc::new(AtomicPosition::new());
+        // half finished
+        pos.set(2);
+        let state = ProgressState::new(Some(4), pos);
+        let mut buf = Vec::new();
+
+        let style = ProgressStyle::with_template("{wide_bar:.blink.red/dim.white}")
+            .unwrap()
+            .progress_chars(CHARS);
+        style.format_state(&state, &mut buf, WIDTH);
+        assert_eq!(
+            &buf[0],
+            "\u{1b}[31m\u{1b}[5m====>\u{1b}[0m\u{1b}[37m\u{1b}[2m---\u{1b}[0m"
         );
     }
 
@@ -1134,7 +1215,7 @@ mod tests {
         style.format_state(&state, &mut buf, WIDTH);
         assert_eq!(
             &buf[0],
-            "\u{1b}[31m\u{1b}[44m====>\u{1b}[32m\u{1b}[46m---\u{1b}[0m\u{1b}[0m"
+            "\u{1b}[31m\u{1b}[44m====>\u{1b}[0m\u{1b}[32m\u{1b}[46m---\u{1b}[0m"
         );
 
         buf.clear();


### PR DESCRIPTION
Fixes #727.

A bar style like `{wide_bar:.blink.red/dim.white}` makes the empty part of the bar blink too.
The filled style is applied as a wrapper around the *whole* bar, with the empty part's style
nested inside it. Colours override across that boundary, but cumulative SGR attributes -- bold,
dim, blink, underline, reverse -- do not; they keep accumulating until the single reset at the
very end. So `\x1b[5m` from the filled style is still in effect while the empty `---` is drawn.

Before:

```
\x1b[31m\x1b[5m====>\x1b[37m\x1b[2m---\x1b[0m\x1b[0m
```

After:

```
\x1b[31m\x1b[5m====>\x1b[0m\x1b[37m\x1b[2m---\x1b[0m
```

This is not a console bug; each segment styled on its own resets correctly. It is the nesting in
`format_bar` and `BarDisplay::fmt`.

The fix styles the filled and empty segments as separate `StyledObject`s so each emits its own
reset. Most of the diff is mechanical: pulling the filled-portion rendering out into a
`FilledDisplay` struct so it can be wrapped. Two smaller pieces go with it -- when no empty style
is given the empty segment falls back to the filled style, so single-colour bars still colour the
whole bar, and the generic outer style-wrap is skipped for `bar`/`wide_bar` since the styling now
happens inside `format_bar`. Each segment still asks console whether colours are enabled and
whether it is writing to stderr, so nothing is hand-emitted.

Two existing byte-level tests change: `wide_element_style` and `multicolor_without_current_style`
now have a reset between the segments instead of two at the tail. For colour-only styles the
rendered result is the same; only the escape bytes moved.

The new test in `src/style.rs` fails on `main` and passes here. `cargo fmt --check`, `cargo
clippy --all-features -- -D warnings` and the 59 lib tests are clean.

I used AI assistance to prepare this, and I have read and verified everything in it myself.