### PR TITLE
Add compact short_pos/short_len/short_per_sec template keys (SI prefixes, 3 sig figs)

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -71,6 +71,28 @@ pub struct HumanCount(pub u64);
 #[derive(Debug)]
 pub struct HumanFloatCount(pub f64);
 
+/// Formats a count compactly using SI (decimal) prefixes and three
+/// significant digits.
+///
+/// Unlike [`HumanCount`], which keeps every digit and groups them with commas,
+/// this renders the order of magnitude in a fixed width. It is handy for rates
+/// or large counts where the exact value matters less than the magnitude, e.g.
+/// a `{per_sec}`-style field that would otherwise jitter in width.
+///
+/// # Examples
+/// ```rust
+/// # use indicatif::HumanShortCount;
+/// assert_eq!("0",     format!("{}", HumanShortCount(0.0)));
+/// assert_eq!("143",   format!("{}", HumanShortCount(143.0)));
+/// assert_eq!("999",   format!("{}", HumanShortCount(999.0)));
+/// assert_eq!("1k",    format!("{}", HumanShortCount(1_000.0)));
+/// assert_eq!("7.21k", format!("{}", HumanShortCount(7_210.0)));
+/// assert_eq!("39.4M", format!("{}", HumanShortCount(39_400_000.0)));
+/// assert_eq!("1.5G",  format!("{}", HumanShortCount(1_500_000_000.0)));
+/// ```
+#[derive(Debug)]
+pub struct HumanShortCount(pub f64);
+
 impl fmt::Display for FormattedDuration {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut t = self.0.as_secs();
@@ -221,6 +243,36 @@ impl fmt::Display for HumanFloatCount {
         }
         Ok(())
     }
+}
+
+impl fmt::Display for HumanShortCount {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match NumberPrefix::decimal(self.0) {
+            NumberPrefix::Standalone(number) => f.write_str(&short_mantissa(number)),
+            NumberPrefix::Prefixed(prefix, number) => {
+                f.write_str(&short_mantissa(number))?;
+                write!(f, "{prefix}")
+            }
+        }
+    }
+}
+
+// Render `number` with enough fraction digits to keep three significant
+// figures, then drop any trailing zeros (and a bare trailing dot). The mantissa
+// handed to us by `NumberPrefix` is always in `[1, 1000)`, and standalone values
+// are below 1000 too, so the magnitude alone decides the fraction width.
+fn short_mantissa(number: f64) -> String {
+    let decimals = match number.abs() {
+        m if m < 10.0 => 2,
+        m if m < 100.0 => 1,
+        _ => 0,
+    };
+    let mut s = format!("{number:.decimals$}");
+    if decimals > 0 {
+        let trimmed = s.trim_end_matches('0').trim_end_matches('.').len();
+        s.truncate(trimmed);
+    }
+    s
 }
 
 #[cfg(test)]
@@ -412,5 +464,27 @@ mod tests {
         assert_eq!("-1,235", format!("{:.0}", HumanFloatCount(-1234.9)));
         // Values that round down are unaffected.
         assert_eq!("1,234", format!("{:.0}", HumanFloatCount(1234.4)));
+    }
+
+    #[test]
+    fn human_short_count() {
+        // Below 1000 the value is shown as-is, trimmed to three significant
+        // figures with no prefix.
+        assert_eq!("0", format!("{}", HumanShortCount(0.0)));
+        assert_eq!("5", format!("{}", HumanShortCount(5.0)));
+        assert_eq!("0.5", format!("{}", HumanShortCount(0.5)));
+        assert_eq!("42.5", format!("{}", HumanShortCount(42.5)));
+        assert_eq!("143", format!("{}", HumanShortCount(143.0)));
+        assert_eq!("999", format!("{}", HumanShortCount(999.0)));
+
+        // At and beyond 1000 an SI prefix is used, still keeping three
+        // significant figures and dropping trailing zeros.
+        assert_eq!("1k", format!("{}", HumanShortCount(1_000.0)));
+        assert_eq!("1.5k", format!("{}", HumanShortCount(1_500.0)));
+        assert_eq!("7.21k", format!("{}", HumanShortCount(7_210.0)));
+        assert_eq!("12.3k", format!("{}", HumanShortCount(12_345.0)));
+        assert_eq!("123k", format!("{}", HumanShortCount(123_456.0)));
+        assert_eq!("39.4M", format!("{}", HumanShortCount(39_400_000.0)));
+        assert_eq!("1.5G", format!("{}", HumanShortCount(1_500_000_000.0)));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,6 +189,10 @@
 //! * `len`: renders the amount of work to be done as an integer
 //! * `human_len`: renders the total length of the bar as an integer, with commas as the thousands
 //!   separator.
+//! * `short_pos`: renders the current position of the bar compactly using SI prefixes and three
+//!   significant digits, i.e. `143`, `7.21k`, `39.4M`.
+//! * `short_len`: renders the total length of the bar compactly using SI prefixes and three
+//!   significant digits, i.e. `143`, `7.21k`, `39.4M`.
 //! * `percent`: renders the current position of the bar as a percentage of the total length (as an integer).
 //! * `percent_precise`: renders the current position of the bar as a percentage of the total length (with 3 fraction digits).
 //! * `bytes`: renders the current position of the bar as bytes (alias of `binary_bytes`).
@@ -204,6 +208,8 @@
 //! * `elapsed_precise`: renders the elapsed time as `HH:MM:SS`.
 //! * `elapsed`: renders the elapsed time as `42s`, `1m` etc.
 //! * `per_sec`: renders the speed in steps per second.
+//! * `short_per_sec`: renders the speed in steps per second compactly using SI prefixes and three
+//!   significant digits, i.e. `143/s`, `7.21k/s`, `39.4M/s`.
 //! * `bytes_per_sec`: renders the speed in bytes per second (alias of `binary_bytes_per_sec`).
 //! * `decimal_bytes_per_sec`: renders the speed in bytes per second using
 //!   power-of-10 units, i.e. `MB`, `kB`, etc.
@@ -263,7 +269,7 @@ mod term_like;
 pub use crate::draw_target::ProgressDrawTarget;
 pub use crate::format::{
     BinaryBytes, DecimalBytes, FormattedDuration, HumanBytes, HumanCount, HumanDuration,
-    HumanFloatCount,
+    HumanFloatCount, HumanShortCount,
 };
 #[cfg(feature = "in_memory")]
 pub use crate::in_memory::InMemoryTerm;

--- a/src/style.rs
+++ b/src/style.rs
@@ -16,7 +16,7 @@ use web_time::Instant;
 use crate::draw_target::LineType;
 use crate::format::{
     BinaryBytes, DecimalBytes, FormattedDuration, HumanBytes, HumanCount, HumanDuration,
-    HumanFloatCount,
+    HumanFloatCount, HumanShortCount,
 };
 use crate::state::{ProgressState, TabExpandedString, DEFAULT_TAB_WIDTH};
 
@@ -263,9 +263,17 @@ impl ProgressStyle {
                             "human_pos" => {
                                 buf.write_fmt(format_args!("{}", HumanCount(pos))).unwrap();
                             }
+                            "short_pos" => {
+                                buf.write_fmt(format_args!("{}", HumanShortCount(pos as f64)))
+                                    .unwrap();
+                            }
                             "len" => buf.write_fmt(format_args!("{len}")).unwrap(),
                             "human_len" => {
                                 buf.write_fmt(format_args!("{}", HumanCount(len))).unwrap();
+                            }
+                            "short_len" => {
+                                buf.write_fmt(format_args!("{}", HumanShortCount(len as f64)))
+                                    .unwrap();
                             }
                             "percent" => buf
                                 .write_fmt(format_args!("{:.*}", 0, state.fraction() * 100f32))
@@ -311,6 +319,9 @@ impl ProgressStyle {
                                     .unwrap();
                                 }
                             }
+                            "short_per_sec" => buf
+                                .write_fmt(format_args!("{}/s", HumanShortCount(state.per_sec())))
+                                .unwrap(),
                             "bytes_per_sec" => buf
                                 .write_fmt(format_args!("{}/s", HumanBytes(state.per_sec() as u64)))
                                 .unwrap(),
@@ -973,6 +984,20 @@ mod tests {
         style.template = Template::from_str("{foo:^5.red.on_blue/green.on_cyan}").unwrap();
         style.format_state(&state, &mut buf, WIDTH);
         assert_eq!(&buf[0], "\u{1b}[31m\u{1b}[44m XXX \u{1b}[0m");
+    }
+
+    #[test]
+    fn short_count_keys() {
+        const WIDTH: u16 = 80;
+        let pos = Arc::new(AtomicPosition::new());
+        pos.set(7210);
+        let state = ProgressState::new(Some(39_400_000), pos);
+        let mut buf = Vec::new();
+
+        let mut style = ProgressStyle::default_bar();
+        style.template = Template::from_str("{short_pos}/{short_len}").unwrap();
+        style.format_state(&state, &mut buf, WIDTH);
+        assert_eq!(&buf[0], "7.21k/39.4M");
     }
 
     #[test]


### PR DESCRIPTION
Closes #637.

For high-throughput bars, `{per_sec}` (and the raw `{pos}`/`{len}`) can print
huge numbers that jitter in width from frame to frame. This adds a compact,
fixed-width alternative using SI prefixes and three significant digits, matching
the format sketched in the issue discussion (`143`, `7.21k`, `39.4M`).

**What's added**

- `HumanShortCount(pub f64)` in `format.rs` — a new public formatter, alongside
  the existing `HumanCount` / `HumanFloatCount`. It reuses `unit_prefix` (already
  a dependency, used by the byte formatters) for the decimal prefix, keeps three
  significant figures, and trims trailing zeros so `1000` renders as `1k` rather
  than `1.00k`.
- Three template keys wired through `style.rs`:
  - `short_pos`, `short_len` — compact counterparts to `human_pos`/`human_len`
  - `short_per_sec` — compact counterpart to `per_sec` (appends `/s`)
- Docs for the new keys in the template-key list, a re-export from the crate
  root, and a doctest on the struct.

**Behavior is opt-in** — no default template or existing key changes; you only
get the new format if you reference one of the new keys.

**Examples**

```
143     -> 143
999     -> 999
1000    -> 1k
7210    -> 7.21k
39400000 -> 39.4M
```

Tested with a unit test over `HumanShortCount`, the struct doctest, and a
`format_state` render test exercising `{short_pos}/{short_len}`. `cargo test`,
`cargo fmt --check`, and `cargo clippy --all-targets` are all clean.

I went with new keys (mirroring `human_pos`/`human_len`) rather than a `:short`
format suffix on the parser since it's smaller and matches the existing
convention, but happy to adjust naming or scope if you'd prefer something else.
